### PR TITLE
Fix lint errors with Rust 1.73 and 1.74

### DIFF
--- a/buildpacks/php/src/layers/platform.rs
+++ b/buildpacks/php/src/layers/platform.rs
@@ -133,7 +133,7 @@ impl Layer for PlatformLayer<'_> {
                         // "--no-interaction",
                         //"--no-progress",
                     ])) {
-                        Ok(_) => {}
+                        Ok(()) => {}
                         Err(_) => {
                             // TODO: Classic uses \r here
                             log_info(format!("no suitable native version of {name} available"));

--- a/buildpacks/php/src/main.rs
+++ b/buildpacks/php/src/main.rs
@@ -146,7 +146,7 @@ impl Buildpack for PhpBuildpack {
 
         log_header("Installing dependencies");
 
-        package_manager::composer::install_dependencies(&context.app_dir, &mut command_env)
+        package_manager::composer::install_dependencies(&context.app_dir, &command_env)
             .map_err(PhpBuildpackError::DependencyInstallation)?;
 
         log_header("Preparing Composer runtime environment");

--- a/buildpacks/php/src/package_manager/composer.rs
+++ b/buildpacks/php/src/package_manager/composer.rs
@@ -18,12 +18,12 @@ pub(crate) enum DependencyInstallationError {
 
 pub(crate) fn install_dependencies(
     dir: &PathBuf,
-    command_env: &mut Env,
+    command_env: &Env,
 ) -> Result<(), DependencyInstallationError> {
     utils::run_command(
         Command::new("composer")
             .current_dir(dir)
-            .envs(&*command_env)
+            .envs(command_env)
             .args([
                 "install",
                 "-vv",

--- a/buildpacks/php/src/platform/generator.rs
+++ b/buildpacks/php/src/platform/generator.rs
@@ -22,9 +22,7 @@ pub(crate) fn ensure_heroku_sys_prefix(name: impl AsRef<str>) -> String {
 
 /// Splits the given string by the given separator, and returns an iterator over the non-empty items, with whitespace trimmed.
 fn split_and_trim_list<'a>(list: &'a str, sep: &'a str) -> impl Iterator<Item = &'a str> {
-    list.split(sep)
-        .map(str::trim)
-        .filter_map(|p| (!p.is_empty()).then_some(p))
+    list.split(sep).map(str::trim).filter(|&p| !p.is_empty())
 }
 
 /// Parses a given repository [`Url`] with optional priority and filter query args into a [`ComposerRepository`].


### PR DESCRIPTION
To unblock #50.

Mostly fixed using `cargo clippy --all-targets --fix`.

```
warning: matching over `()` is more explicit
   --> buildpacks/php/src/layers/platform.rs:136:28
    |
136 |                         Ok(_) => {}
    |                            ^ help: use `()` instead of `_`: `()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ignored_unit_patterns
note: the lint level is defined here
   --> buildpacks/php/src/main.rs:1:9
    |
1   | #![warn(clippy::pedantic)]
    |         ^^^^^^^^^^^^^^^^
    = note: `#[warn(clippy::ignored_unit_patterns)]` implied by `#[warn(clippy::pedantic)]`

warning: this `.filter_map` can be written more simply using `.filter`
  --> buildpacks/php/src/platform/generator.rs:25:5
   |
25 | /     list.split(sep)
26 | |         .map(str::trim)
27 | |         .filter_map(|p| (!p.is_empty()).then_some(p))
   | |_____________________________________________________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_filter_map
   = note: `#[warn(clippy::unnecessary_filter_map)]` on by default

warning: this argument is a mutable reference, but not used mutably
  --> buildpacks/php/src/package_manager/composer.rs:21:18
   |
21 |     command_env: &mut Env,
   |                  ^^^^^^^^ help: consider changing to: `&Env`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_ref_mut
```

As seen in (for the Rust 1.73 parts at least):
https://github.com/heroku/buildpacks-php/actions/runs/6456037385/job/17524705181?pr=50

GUS-W-14258401.