### PR TITLE
Update buildpack metadata in buildpack.toml

### DIFF
--- a/buildpacks/php/CHANGELOG.md
+++ b/buildpacks/php/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated buildpack display name and description. ([#57](https://github.com/heroku/buildpack-php/pull/57))
+
 ## [0.1.1] - 2023-06-30
 
 ### Added

--- a/buildpacks/php/buildpack.toml
+++ b/buildpacks/php/buildpack.toml
@@ -3,9 +3,9 @@ api = "0.9"
 [buildpack]
 id = "heroku/php"
 version = "0.1.1"
-name = "PHP"
+name = "Heroku PHP"
 homepage = "https://github.com/heroku/buildpacks-php"
-description = "Heroku's official PHP Cloud Native Buildpack."
+description = "Heroku's buildpack for PHP applications."
 keywords = ["php", "heroku"]
 clear-env = true
 
@@ -18,7 +18,5 @@ id = "heroku-20"
 [[stacks]]
 id = "heroku-22"
 
-[metadata]
 [metadata.release]
-[metadata.release.image]
-repository = "docker.io/heroku/buildpack-php"
+image = { repository = "docker.io/heroku/buildpack-php" }


### PR DESCRIPTION
Adjusts the buildpack `name` and `description` in `buildpack.toml` to match the style discussed in:
https://github.com/heroku/cnb-builder-images/issues/408

These fields are used by the CNB registry and can also be seen in the output of `pack builder inspect`. They are not used by `pack build` or Kodon.

In addition, I've cleaned up the `[metadata]` table/subtables to match the more concise style used by the Procfile and Python CNBs.

GUS-W-14121598.