### PR TITLE
Switch to Cargo.toml based lint configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,13 @@ members = [
     "buildpacks/php",
     "composer"
 ]
+
+[workspace.package]
+edition = "2021"
+rust-version = "1.74"
+
+[workspace.lints.rust]
+unused_crate_dependencies = "warn"
+
+[workspace.lints.clippy]
+pedantic = "warn"

--- a/buildpacks/php/Cargo.toml
+++ b/buildpacks/php/Cargo.toml
@@ -2,8 +2,11 @@
 name = "php-buildpack"
 version = "0.0.0"
 publish = false
-edition = "2021"
-rust-version = "1.70"
+edition.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 chrono = "0.4"

--- a/buildpacks/php/src/main.rs
+++ b/buildpacks/php/src/main.rs
@@ -1,6 +1,3 @@
-#![warn(clippy::pedantic)]
-#![warn(unused_crate_dependencies)]
-
 mod bootstrap;
 mod errors;
 mod layers;

--- a/buildpacks/php/tests/integration/main.rs
+++ b/buildpacks/php/tests/integration/main.rs
@@ -5,7 +5,8 @@
 //!
 //! See: <https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html#Implications>
 
-#![warn(clippy::pedantic)]
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
 
 mod smoke;
 mod utils;

--- a/composer/Cargo.toml
+++ b/composer/Cargo.toml
@@ -2,9 +2,11 @@
 name = "composer"
 version = "0.1.0"
 publish = false
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
 
 [dependencies]
 derive_more = "0.99"

--- a/composer/src/lib.rs
+++ b/composer/src/lib.rs
@@ -1,6 +1,3 @@
-#![warn(clippy::pedantic)]
-#![warn(unused_crate_dependencies)]
-
 use derive_more::{Deref, From};
 use monostate::MustBe;
 use serde::de::{Error, MapAccess, SeqAccess, Visitor};


### PR DESCRIPTION
As of the Cargo included in Rust 1.74, lints can now be configured in `Cargo.toml` across whole crates/workspaces:
https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html
https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-lints-section
https://doc.rust-lang.org/stable/cargo/reference/workspaces.html#the-lints-table

This reduces the boilerplate, and the chance that we forget to enable lints in some targets. The only thing we need to remember is to add the `[lints] workspace = true` to any new crates in the future.

Since this feature requires Rust 1.74, the MSRV has also been bumped (however, libcnb 0.16.0 already requires Rust 1.74, so in practice this is a no-op).

GUS-W-14523794.