### PR TITLE
Enable additional rustc and Clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,11 @@ edition = "2021"
 rust-version = "1.74"
 
 [workspace.lints.rust]
+unreachable_pub = "warn"
+unsafe_code = "warn"
 unused_crate_dependencies = "warn"
 
 [workspace.lints.clippy]
+panic_in_result_fn = "warn"
 pedantic = "warn"
+unwrap_used = "warn"

--- a/buildpacks/php/src/bootstrap.rs
+++ b/buildpacks/php/src/bootstrap.rs
@@ -9,12 +9,12 @@ use std::path::PathBuf;
 const PHP_VERSION: &str = "8.1.12";
 const COMPOSER_VERSION: &str = "2.4.4";
 const CLASSIC_BUILDPACK_VERSION: &str = "heads/cnb-installer";
-pub(crate) const CLASSIC_BUILDPACK_INSTALLER_SUBDIR: &str = "support/installer";
+const CLASSIC_BUILDPACK_INSTALLER_SUBDIR: &str = "support/installer";
 
 pub(crate) struct BootstrapResult {
-    pub env: Env,
-    pub platform_installer_path: PathBuf,
-    pub classic_buildpack_path: PathBuf,
+    pub(crate) env: Env,
+    pub(crate) platform_installer_path: PathBuf,
+    pub(crate) classic_buildpack_path: PathBuf,
 }
 
 pub(crate) fn bootstrap(

--- a/buildpacks/php/src/layers/bootstrap.rs
+++ b/buildpacks/php/src/layers/bootstrap.rs
@@ -17,9 +17,9 @@ pub(crate) struct BootstrapLayerMetadata {
 }
 
 pub(crate) struct BootstrapLayer {
-    pub url: String,
-    pub strip_path_components: usize,
-    pub directory: PathBuf,
+    pub(crate) url: String,
+    pub(crate) strip_path_components: usize,
+    pub(crate) directory: PathBuf,
 }
 
 impl Layer for BootstrapLayer {

--- a/buildpacks/php/src/layers/composer_env.rs
+++ b/buildpacks/php/src/layers/composer_env.rs
@@ -9,8 +9,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus};
 
 pub(crate) struct ComposerEnvLayer<'a> {
-    pub command_env: &'a Env,
-    pub dir: &'a PathBuf,
+    pub(crate) command_env: &'a Env,
+    pub(crate) dir: &'a PathBuf,
 }
 
 impl Layer for ComposerEnvLayer<'_> {

--- a/buildpacks/php/src/layers/platform.rs
+++ b/buildpacks/php/src/layers/platform.rs
@@ -21,8 +21,8 @@ pub(crate) struct PlatformLayerMetadata {
 }
 
 pub(crate) struct PlatformLayer<'a> {
-    pub command_env: &'a Env,
-    pub platform_json: &'a ComposerRootPackage,
+    pub(crate) command_env: &'a Env,
+    pub(crate) platform_json: &'a ComposerRootPackage,
 }
 
 impl Layer for PlatformLayer<'_> {

--- a/buildpacks/php/src/main.rs
+++ b/buildpacks/php/src/main.rs
@@ -34,7 +34,7 @@ use exponential_backoff as _;
 #[cfg(test)]
 use libcnb_test as _;
 
-pub(crate) struct PhpBuildpack;
+struct PhpBuildpack;
 
 impl Buildpack for PhpBuildpack {
     type Platform = GenericPlatform;
@@ -183,7 +183,7 @@ impl Buildpack for PhpBuildpack {
 }
 
 #[derive(Debug)]
-pub(crate) enum PhpBuildpackError {
+enum PhpBuildpackError {
     ProjectLoad(ProjectLoadError),
     BootstrapLayer(BootstrapLayerError),
     PlatformRepositoryUrl(PlatformRepositoryUrlError),
@@ -195,7 +195,7 @@ pub(crate) enum PhpBuildpackError {
 }
 
 #[derive(Debug)]
-pub(crate) enum PhpBuildpackNotice {
+enum PhpBuildpackNotice {
     ProjectLoader(ProjectLoaderNotice),
     PlatformJson(PlatformJsonNotice),
 }

--- a/buildpacks/php/src/package_manager/composer.rs
+++ b/buildpacks/php/src/package_manager/composer.rs
@@ -58,7 +58,7 @@ pub(crate) enum PlatformExtractorNotice {
 }
 
 /// Checks whether the given package name represents what Composer refers to as a "platform package".
-pub(crate) fn is_platform_package(name: impl AsRef<str>) -> bool {
+fn is_platform_package(name: impl AsRef<str>) -> bool {
     let name = name.as_ref();
     // same regex used by Composer as well
     regex!(r"^(?i)(?:php(?:-64bit|-ipv6|-zts|-debug)?|hhvm|(?:ext|lib)-[a-z0-9](?:[_.-]?[a-z0-9]+)*|composer(?:-(?:plugin|runtime)-api)?)$")
@@ -73,12 +73,12 @@ pub(crate) fn is_platform_package(name: impl AsRef<str>) -> bool {
 }
 
 /// Checks whether the given list of package links (typically from "require") contains a requirement for a language runtime.
-pub(crate) fn has_runtime_link(links: &HashMap<String, String>) -> bool {
+fn has_runtime_link(links: &HashMap<String, String>) -> bool {
     links.contains_key("heroku-sys/php")
 }
 
 /// Extracts links to platform packages (see [`is_platform_package`]) and prefix them using [`ensure_heroku_sys_prefix`].
-pub(crate) fn extract_platform_links_with_heroku_sys<T: Clone>(
+fn extract_platform_links_with_heroku_sys<T: Clone>(
     links: &HashMap<String, T>,
 ) -> Option<HashMap<String, T>> {
     let ret = links
@@ -166,7 +166,7 @@ pub(crate) enum ComposerLockVersionError {
 /// Generates requirements for Composer and the Composer Plugin API version that match the given [`ComposerLock`].
 ///
 /// The returned [`Warned`] struct contains a hash map of the generated requirements, and a list of [`PlatformExtractorNotice`s](PlatformExtractorNotice) encountered during processing.
-pub(crate) fn requires_for_composer_itself(
+fn requires_for_composer_itself(
     lock: &ComposerLock,
 ) -> Result<Warned<HashMap<String, String>, ComposerLockVersionNotice>, ComposerLockVersionError> {
     let mut notices = Vec::new();

--- a/buildpacks/php/src/platform.rs
+++ b/buildpacks/php/src/platform.rs
@@ -62,7 +62,7 @@ pub(crate) fn platform_repository_urls_from_default_and_build_context(
 
 /// Returns a list of platform repository [`Url`s](Url), computed from the given default [`Url`s](Url)
 /// and space-separated list of additional URL strings (typically user-supplied).
-pub(crate) fn platform_repository_urls_from_defaults_and_list(
+fn platform_repository_urls_from_defaults_and_list(
     default_urls: &[Url],
     extra_urls_list: impl AsRef<str>,
 ) -> Result<Vec<Url>, PlatformRepositoryUrlError> {

--- a/buildpacks/php/src/platform/generator.rs
+++ b/buildpacks/php/src/platform/generator.rs
@@ -99,23 +99,23 @@ pub(crate) enum PlatformGeneratorError {
 #[derive(Default, Debug)]
 pub(crate) struct PlatformJsonGeneratorInput {
     /// The desired [`ComposerStability`] for the root package's `minimum-stability` field
-    pub minimum_stability: ComposerStability,
+    pub(crate) minimum_stability: ComposerStability,
     /// The desired value for the root package's `prefer-stable` field
-    pub prefer_stable: bool,
+    pub(crate) prefer_stable: bool,
     /// The direct platform requirements from the root dependencies of the source project
-    pub platform_require: HashMap<String, String>,
+    pub(crate) platform_require: HashMap<String, String>,
     /// The direct platform dev requirements from the root dependencies of the source project
-    pub platform_require_dev: HashMap<String, String>,
+    pub(crate) platform_require_dev: HashMap<String, String>,
     /// A list of packages from the source project's locked dependencies
-    pub packages: Vec<ComposerPackage>,
+    pub(crate) packages: Vec<ComposerPackage>,
     /// A list of packages from the source project's locked dev dependencies
-    pub packages_dev: Vec<ComposerPackage>,
+    pub(crate) packages_dev: Vec<ComposerPackage>,
     /// A list of additional requirements to be placed into the generated package's root requirements
-    pub additional_require: Option<HashMap<String, String>>,
+    pub(crate) additional_require: Option<HashMap<String, String>>,
     /// A list of additional requirements to be placed into the generated package's root dev requirements
-    pub additional_require_dev: Option<HashMap<String, String>>,
+    pub(crate) additional_require_dev: Option<HashMap<String, String>>,
     /// Additional [`ComposerRepository`] entries to be placed into the generated package
-    pub additional_repositories: Option<Vec<ComposerRepository>>,
+    pub(crate) additional_repositories: Option<Vec<ComposerRepository>>,
 }
 impl From<&ComposerLock> for PlatformJsonGeneratorInput {
     fn from(lock: &ComposerLock) -> Self {

--- a/buildpacks/php/src/utils.rs
+++ b/buildpacks/php/src/utils.rs
@@ -75,9 +75,7 @@ pub(crate) fn download_and_unpack_tgz_with_components_stripped_and_only_entries_
         })
 }
 
-pub(crate) fn download(
-    uri: &str,
-) -> Result<Box<dyn io::Read + Send + Sync + 'static>, DownloadUnpackError> {
+fn download(uri: &str) -> Result<Box<dyn io::Read + Send + Sync + 'static>, DownloadUnpackError> {
     // TODO: Timeouts: https://docs.rs/ureq/latest/ureq/struct.AgentBuilder.html?search=timeout
     Ok(ureq::get(uri)
         .call()

--- a/buildpacks/php/tests/integration/utils.rs
+++ b/buildpacks/php/tests/integration/utils.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 ///a
 /// The smoke integration tests need to ensure the container runs as expected.
 /// This function is catering to that use-case and is not useful in other contexts.
-pub(crate) fn start_container_assert_basic_http_response(
+fn start_container_assert_basic_http_response(
     context: &TestContext,
     expected_http_response_body_contains: &str,
 ) {
@@ -36,7 +36,7 @@ pub(crate) fn start_container_assert_basic_http_response(
     );
 }
 
-pub(crate) fn http_request_backoff<F, T, E>(request_fn: F) -> Result<T, E>
+fn http_request_backoff<F, T, E>(request_fn: F) -> Result<T, E>
 where
     F: Fn() -> Result<T, E>,
 {
@@ -89,11 +89,11 @@ pub(crate) fn smoke_test<P, B>(
     });
 }
 
-pub const DEFAULT_INTEGRATION_TEST_BUILDER: &str = "heroku/builder:22";
+const DEFAULT_INTEGRATION_TEST_BUILDER: &str = "heroku/builder:22";
 
-pub const UREQ_RESPONSE_RESULT_EXPECT_MESSAGE: &str = "http request should be successful";
+const UREQ_RESPONSE_RESULT_EXPECT_MESSAGE: &str = "http request should be successful";
 
-pub const UREQ_RESPONSE_AS_STRING_EXPECT_MESSAGE: &str =
+const UREQ_RESPONSE_AS_STRING_EXPECT_MESSAGE: &str =
     "http response body should be convertible to a string";
 
 const PORT: u16 = 8080;

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+allow-unwrap-in-tests = true


### PR DESCRIPTION
Enables some off-by-default lints that we already use in the `libcnb.rs` repository.

https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unreachable-pub
https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unsafe-code
https://rust-lang.github.io/rust-clippy/master/index.html#/panic_in_result_fn
https://rust-lang.github.io/rust-clippy/master/index.html#/unwrap_used

GUS-W-14523794.