### PR TITLE
Simplify Cargo metadata for `publish = false` crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "composer"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "derive_more",
  "monostate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.74"
+rust-version = "1.75"
 
 [workspace.lints.rust]
 unreachable_pub = "warn"

--- a/buildpacks/php/Cargo.toml
+++ b/buildpacks/php/Cargo.toml
@@ -1,7 +1,5 @@
 [package]
 name = "php-buildpack"
-version = "0.0.0"
-publish = false
 edition.workspace = true
 rust-version.workspace = true
 

--- a/composer/Cargo.toml
+++ b/composer/Cargo.toml
@@ -1,7 +1,5 @@
 [package]
 name = "composer"
-version = "0.1.0"
-publish = false
 edition.workspace = true
 rust-version.workspace = true
 


### PR DESCRIPTION
As of Cargo 1.75 the `version` property in `Cargo.toml` is now optional, and if omitted is the same as having specified `version = "0.0.0"` and `publish = false`:
https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-175-2023-12-28
https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field

Therefore for crates that we do not publish, we can now remove both the `version` and `publish` properties, avoiding the need for the fake `0.0.0` version that differs from the actual buildpack version in `buildpack.toml`.

GUS-W-14821120.