### PR TITLE
Fix lint errors with Rust 1.75

### DIFF
--- a/buildpacks/php/src/php_project.rs
+++ b/buildpacks/php/src/php_project.rs
@@ -119,6 +119,7 @@ pub(crate) enum PlatformJsonNotice {
 }
 
 #[derive(Default)]
+#[allow(clippy::struct_field_names)]
 pub(crate) struct Project {
     #[allow(dead_code)]
     composer_json_name: String,


### PR DESCRIPTION
This repo's CI is currently failing on `main` due to a new lint introduced in Rust 1.75:
https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-175

```
warning: all fields have the same prefix: `composer`
   --> buildpacks/php/src/php_project.rs:122:1
    |
122 | / pub(crate) struct Project {
123 | |     #[allow(dead_code)]
124 | |     composer_json_name: String,
125 | |     #[allow(dead_code)]
...   |
129 | |     composer_lock: Option<ComposerLock>,
130 | | }
    | |_^
    |
    = help: remove the prefixes
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#struct_field_names
    = note: `-W clippy::struct-field-names` implied by `-W clippy::pedantic`
    = help: to override `-W clippy::pedantic` add `#[allow(clippy::struct_field_names)]`
```

I've chosen to `allow` the failure, given that `Project` is generic, so prefixing the fields makes sense (in the future I can imagine there will be some non-composer fields, which won't have the prefix).

See:
https://rust-lang.github.io/rust-clippy/master/index.html#struct_field_names

GUS-W-14821274.