### PR TITLE
Fix lint failures with Rust 1.76

### DIFF
--- a/buildpacks/php/src/php_project.rs
+++ b/buildpacks/php/src/php_project.rs
@@ -149,7 +149,7 @@ impl Project {
         &self,
         stack: &str,
         installer_path: &Path,
-        platform_repositories: &Vec<Url>,
+        platform_repositories: &[Url],
         dev: bool,
     ) -> Result<Warned<ComposerRootPackage, PlatformJsonNotice>, PlatformJsonError> {
         let mut extractor_notices = Vec::new();

--- a/buildpacks/php/src/platform.rs
+++ b/buildpacks/php/src/platform.rs
@@ -107,7 +107,7 @@ pub(crate) fn webservers_json(
     stack: &str,
     installer_path: &Path,
     classic_buildpack_path: &Path,
-    platform_repositories: &Vec<Url>,
+    platform_repositories: &[Url],
 ) -> Result<ComposerRootPackage, WebserversJsonError> {
     let webservers_generator_input = generator::PlatformJsonGeneratorInput {
         additional_require: Some(HashMap::from([

--- a/buildpacks/php/src/platform/generator.rs
+++ b/buildpacks/php/src/platform/generator.rs
@@ -174,7 +174,7 @@ pub(crate) fn generate_platform_json(
     input: &PlatformJsonGeneratorInput,
     stack: &str,
     installer_path: &Path,
-    platform_repositories: &Vec<Url>,
+    platform_repositories: &[Url],
 ) -> Result<ComposerRootPackage, PlatformGeneratorError> {
     if platform_repositories.is_empty() {
         return Err(PlatformGeneratorError::EmptyPlatformRepositoriesList);


### PR DESCRIPTION
Fixes the following failure on `main`:

```
 error: writing `&Vec` instead of `&[_]` involves a new object where a slice will do
   --> buildpacks/php/src/platform/generator.rs:177:28
    |
177 |     platform_repositories: &Vec<Url>,
    |                            ^^^^^^^^^ help: change this to: `&[Url]`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg
    = note: `-D clippy::ptr-arg` implied by `-D warnings`
```

As seen in:
https://github.com/heroku/buildpacks-php/actions/runs/8109044448/job/22163445587?pr=82#step:5:275

Docs:
https://rust-lang.github.io/rust-clippy/master/index.html#/ptr_arg
