### PR TITLE
composer.json 'scripts' entries can be strings

### DIFF
--- a/buildpacks/php/CHANGELOG.md
+++ b/buildpacks/php/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `buildpack.toml` declaration of `[[stacks]]` has been replaced with `[[targets]]`, currently supporting Ubuntu 20.04 and 22.04 (both `amd64`)
 - Bump versions of Composer and minimal PHP for bootstrapping to 2.7.6 and 8.3.7
 
+### Fixed
+
+- Strings should be allowed as values in `scripts` object in `composer.json` ([#90](https://github.com/heroku/buildpacks-php/issues/90))
+
 ## [0.1.2] - 2023-10-24
 
 ### Changed

--- a/buildpacks/php/tests/fixtures/smoke/hello-world/composer.json
+++ b/buildpacks/php/tests/fixtures/smoke/hello-world/composer.json
@@ -16,5 +16,12 @@
 	},
 	"config":{
 		"bin-dir": "sbin"
+	},
+	"scripts": {
+		"foo": "echo 'foo'",
+		"bar": [
+			"echo 'one'",
+			"echo 'two'"
+		]
 	}
 }

--- a/composer/src/lib.rs
+++ b/composer/src/lib.rs
@@ -118,6 +118,7 @@ pub struct ComposerBasePackage {
     pub repositories: Option<Vec<ComposerRepository>>,
     pub require: Option<HashMap<String, String>>,
     pub require_dev: Option<HashMap<String, String>>,
+    #[serde_as(as = "Option<HashMap<_, OneOrMany<_, PreferOne>>>")]
     pub scripts: Option<HashMap<String, Vec<String>>>,
     pub scripts_descriptions: Option<HashMap<String, String>>,
     pub source: Option<ComposerPackageSource>,


### PR DESCRIPTION
Each value in the object can be a string for a single command, or list of commands:

```json
{
  "scripts": {
    "foo": [
      "first-command",
      "second-command"
    ],
    "bar": "another-command"
  }
}
```

Fixes #90