### PR TITLE
Work around Pack 'no compatible stacks among provided buildpacks' error

### DIFF
--- a/buildpacks/php/buildpack.toml
+++ b/buildpacks/php/buildpack.toml
@@ -11,6 +11,14 @@ keywords = ["php", "heroku"]
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
 
+# Temporary workaround until Buildpacks GHAs get a release
+# which includes Pack 0.34.0 or later:
+# https://github.com/buildpacks/github-actions/releases
+# https://github.com/buildpacks/pack/releases/tag/v0.34.0
+# https://github.com/buildpacks/pack/pull/2081
+[[stacks]]
+id = "*"
+
 [[targets]]
 os = "linux"
 arch = "amd64"


### PR DESCRIPTION
Fixed by https://github.com/buildpacks/pack/pull/2081 and released in https://github.com/buildpacks/pack/releases/tag/v0.34.0 but not in a Buildpacks GHAs release at https://github.com/buildpacks/github-actions/releases yet