### PR TITLE
Drop stacks workaround in buildpack.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.7.3
       - name: Install Pack CLI
-        uses: buildpacks/github-actions/setup-pack@v5.7.0
+        uses: buildpacks/github-actions/setup-pack@v5.7.1
       - name: Pull builder image
         run: docker pull ${{ env.INTEGRATION_TEST_CNB_BUILDER }}
       # The integration tests are annotated with the `ignore` attribute, allowing us to run

--- a/buildpacks/php/buildpack.toml
+++ b/buildpacks/php/buildpack.toml
@@ -11,14 +11,6 @@ keywords = ["php", "heroku"]
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
 
-# Temporary workaround until Buildpacks GHAs get a release
-# which includes Pack 0.34.0 or later:
-# https://github.com/buildpacks/github-actions/releases
-# https://github.com/buildpacks/pack/releases/tag/v0.34.0
-# https://github.com/buildpacks/pack/pull/2081
-[[stacks]]
-id = "*"
-
 [[targets]]
 os = "linux"
 arch = "amd64"


### PR DESCRIPTION
Added in 75153c2, but now https://github.com/buildpacks/github-actions/pull/283 is out which incorporates a Pack version that has a fix.