### PR TITLE
Fix Clippy lints on newer Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["buildpacks/php", "composer"]
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.85"
 
 [workspace.lints.rust]
 unreachable_pub = "warn"

--- a/buildpacks/php/src/main.rs
+++ b/buildpacks/php/src/main.rs
@@ -178,7 +178,7 @@ impl Buildpack for PhpBuildpack {
                     Details: {libcnb_error}
                 ", iehs = errors::INTERNAL_ERROR_HELP_STRING},
             ),
-        };
+        }
     }
 }
 

--- a/buildpacks/php/src/package_manager/composer.rs
+++ b/buildpacks/php/src/package_manager/composer.rs
@@ -285,7 +285,7 @@ pub(crate) fn ensure_runtime_requirement(
             ),
         ] {
             for (name, _) in requirements.clone().unwrap_or_default() {
-                *marker |= metapackages.get(&name).map_or(false, |package| {
+                *marker |= metapackages.get(&name).is_some_and(|package| {
                     // here, we only look at a package's require list, not require-dev, which only has an effect in the root of a composer.json
                     // (since every library has its own list of dev requirements for testing etc, and that should never be installed into a project using that library)
                     has_runtime_link(&package.package.require.clone().unwrap_or_default())

--- a/buildpacks/php/src/platform/generator.rs
+++ b/buildpacks/php/src/platform/generator.rs
@@ -58,7 +58,7 @@ fn composer_repository_from_repository_url(
             ONLY_QUERY_ARG_NAME | EXCLUDE_QUERY_ARG_NAME => {
                 if filters.is_some() {
                     return Err(ComposerRepositoryFromRepositoryUrlError::MultipleFilters);
-                };
+                }
                 let filter_list = split_and_trim_list(v, ",")
                     .map(ensure_heroku_sys_prefix)
                     .collect();
@@ -178,7 +178,7 @@ pub(crate) fn generate_platform_json(
 ) -> Result<ComposerRootPackage, PlatformGeneratorError> {
     if platform_repositories.is_empty() {
         return Err(PlatformGeneratorError::EmptyPlatformRepositoriesList);
-    };
+    }
 
     let stack_provide = stack_provide_from_stack_name(stack)?;
 
@@ -274,9 +274,8 @@ pub(crate) fn generate_platform_json(
             repositories.push(
                 metapackages
                     // ... and insert a require for each of them
-                    .map(|package| {
+                    .inspect(|package| {
                         requires.insert(package.name.clone(), package.version.clone());
-                        package
                     })
                     .collect(),
             );

--- a/buildpacks/php/tests/integration/utils.rs
+++ b/buildpacks/php/tests/integration/utils.rs
@@ -52,7 +52,6 @@ where
                 None => return result,
                 Some(backoff_duration) => {
                     std::thread::sleep(backoff_duration);
-                    continue;
                 }
             },
         }


### PR DESCRIPTION
Fixes:

```
warning: this `continue` expression is redundant
  --> buildpacks/php/tests/integration/utils.rs:55:21
   |
55 |                     continue;
   |                     ^^^^^^^^
   |
   = help: consider dropping the `continue` expression
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_continue
   = note: `-W clippy::needless-continue` implied by `-W clippy::pedantic`
   = help: to override `-W clippy::pedantic` add `#[allow(clippy::needless_continue)]`

warning: `php-buildpack` (test "integration") generated 1 warning
warning: this `map_or` can be simplified
   --> buildpacks/php/src/package_manager/composer.rs:288:28
    |
288 |   ...   *marker |= metapackages.get(&name).map_or(false, |package| {
    |  __________________^
289 | | ...       // here, we only look at a package's require list, not require-dev, which only ...
290 | | ...       // (since every library has its own list of dev requirements for testing etc, a...
291 | | ...       has_runtime_link(&package.package.require.clone().unwrap_or_default())
292 | | ...   });
    | |________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or
    = note: `#[warn(clippy::unnecessary_map_or)]` on by default
help: use is_some_and instead
    |
288 -                 *marker |= metapackages.get(&name).map_or(false, |package| {
288 +                 *marker |= metapackages.get(&name).is_some_and(|package| {
    |

warning: unnecessary semicolon
  --> buildpacks/php/src/platform/generator.rs:61:18
   |
61 |                 };
   |                  ^ help: remove
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_semicolon
   = note: `-W clippy::unnecessary-semicolon` implied by `-W clippy::pedantic`
   = help: to override `-W clippy::pedantic` add `#[allow(clippy::unnecessary_semicolon)]`

warning: unnecessary semicolon
   --> buildpacks/php/src/platform/generator.rs:181:6
    |
181 |     };
    |      ^ help: remove
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_semicolon

warning: using `map` over `inspect`
   --> buildpacks/php/src/platform/generator.rs:277:22
    |
277 |                     .map(|package| {
    |                      ^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_inspect
    = note: `#[warn(clippy::manual_inspect)]` on by default
help: try
    |
277 ~                     .inspect(|package| {
278 ~                         requires.insert(package.name.clone(), package.version.clone());
    |

warning: unnecessary semicolon
   --> buildpacks/php/src/main.rs:181:10
    |
181 |         };
    |          ^ help: remove
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_semicolon
```