### PR TITLE
Remove unused scripts field 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,6 +1226,7 @@ dependencies = [
  "serde_json",
  "shell-words",
  "tar",
+ "tempfile",
  "ureq",
  "url",
  "warned",

--- a/buildpacks/php/CHANGELOG.md
+++ b/buildpacks/php/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The "scripts" key in `composer.json` no longer fails when provided with an object as a sub-value. ([#168](https://github.com/heroku/buildpacks-php/pull/168))
+
 ## [0.2.2] - 2025-04-03
 
 ### Changed

--- a/buildpacks/php/Cargo.toml
+++ b/buildpacks/php/Cargo.toml
@@ -31,3 +31,4 @@ assert-json-diff = "2"
 exponential-backoff = "1"
 figment = { version = "0.10", features = ["toml"] }
 libcnb-test = "=0.28.1"
+tempfile = "3.19.1"

--- a/buildpacks/php/Cargo.toml
+++ b/buildpacks/php/Cargo.toml
@@ -31,4 +31,4 @@ assert-json-diff = "2"
 exponential-backoff = "1"
 figment = { version = "0.10", features = ["toml"] }
 libcnb-test = "=0.28.1"
-tempfile = "3.19.1"
+tempfile = "3"

--- a/buildpacks/php/src/main.rs
+++ b/buildpacks/php/src/main.rs
@@ -35,6 +35,8 @@ use libherokubuildpack::log::{log_error, log_header, log_info};
 use exponential_backoff as _;
 #[cfg(test)]
 use libcnb_test as _;
+#[cfg(test)]
+use tempfile as _;
 
 struct PhpBuildpack;
 

--- a/buildpacks/php/tests/integration/smoke.rs
+++ b/buildpacks/php/tests/integration/smoke.rs
@@ -5,8 +5,9 @@
 //!
 //! These tests are strictly happy-path tests and do not assert any output of the buildpack.
 
-use crate::utils::{builder, default_buildpacks, smoke_test};
-use libcnb_test::BuildpackReference;
+use crate::utils::{builder, default_buildpacks, smoke_test, target_triple};
+use indoc::formatdoc;
+use libcnb_test::{BuildConfig, BuildpackReference, TestRunner};
 
 #[test]
 #[ignore = "integration test"]
@@ -17,6 +18,30 @@ fn smoke_test_bundled_hello_world_app() {
         vec![BuildpackReference::CurrentCrate],
         "Hello World",
     );
+}
+
+#[test]
+#[ignore = "integration test"]
+fn smoke_test_composer_json_scripts_as_objects() {
+    // TODO modify the composer.json to assert https://github.com/heroku/buildpacks-php/issues/81
+    let app_dir = "tests/fixtures/smoke/hello-world";
+
+    let build_config = BuildConfig::new(builder(), app_dir)
+        .buildpacks(vec![BuildpackReference::CurrentCrate])
+        .target_triple(target_triple(builder()))
+        .to_owned();
+
+    TestRunner::default().build(&build_config, |context| {
+        assert_eq!(
+            formatdoc! {"
+                /layers/heroku_php/platform/bin/php
+                /layers/heroku_php/platform/bin/php
+                /layers/heroku_php/platform/bin/php
+            "}
+            .trim(),
+            context.run_shell_command("which -a php").stdout.trim()
+        );
+    });
 }
 
 #[test]

--- a/buildpacks/php/tests/integration/smoke.rs
+++ b/buildpacks/php/tests/integration/smoke.rs
@@ -5,12 +5,10 @@
 //!
 //! These tests are strictly happy-path tests and do not assert any output of the buildpack.
 
-use crate::utils::{builder, copy_dir_all, default_buildpacks, smoke_test, target_triple};
-use indoc::formatdoc;
+use crate::utils::{builder, default_buildpacks, smoke_test, target_triple};
 use libcnb_test::{BuildConfig, BuildpackReference, TestRunner};
 use serde_json::json;
 use std::fs;
-use std::path::PathBuf;
 
 #[test]
 #[ignore = "integration test"]
@@ -26,57 +24,40 @@ fn smoke_test_bundled_hello_world_app() {
 #[test]
 #[ignore = "integration test"]
 fn smoke_test_composer_json_scripts_as_objects() {
-    let temp = tempfile::tempdir().unwrap();
-    let source = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/fixtures/smoke/hello-world")
-        .canonicalize()
-        .unwrap();
-    let app_dir = temp.path();
-    copy_dir_all(source, app_dir).unwrap();
-
-    let mut composer_json = serde_json::from_str::<serde_json::Map<_, _>>(
-        &fs::read_to_string(app_dir.join("composer.json")).unwrap(),
-    )
-    .unwrap();
-
-    composer_json.insert(
-        "scripts".to_string(),
-        json!({
-            "auto-scripts": {
-                "cache:clear": "echo 'cache:clear'",
-                "assets:install %PUBLIC_DIR%": "echo 'assets:install'",
-                "importmap:install": "echo 'importmap:install'"
-            },
-            "post-install-cmd": [
-                "@auto-scripts"
-            ],
-            "post-update-cmd": [
-                "@auto-scripts"
-            ]
-        }),
-    );
-    fs::write(
-        app_dir.join("composer.json"),
-        serde_json::to_string(&composer_json).unwrap(),
-    )
-    .unwrap();
-
-    let build_config = BuildConfig::new(builder(), app_dir)
+    let build_config = BuildConfig::new(builder(), "tests/fixtures/smoke/hello-world")
         .buildpacks(vec![BuildpackReference::CurrentCrate])
         .target_triple(target_triple(builder()))
+        .app_dir_preprocessor(|app_dir| {
+            let mut composer_json = serde_json::from_str::<serde_json::Map<_, _>>(
+                &fs::read_to_string(app_dir.join("composer.json")).unwrap(),
+            )
+            .unwrap();
+
+            composer_json.insert(
+                "scripts".to_string(),
+                json!({
+                    "auto-scripts": {
+                        "cache:clear": "echo 'cache:clear'",
+                        "assets:install %PUBLIC_DIR%": "echo 'assets:install'",
+                        "importmap:install": "echo 'importmap:install'"
+                    },
+                    "post-install-cmd": [
+                        "@auto-scripts"
+                    ],
+                    "post-update-cmd": [
+                        "@auto-scripts"
+                    ]
+                }),
+            );
+            fs::write(
+                app_dir.join("composer.json"),
+                serde_json::to_string(&composer_json).unwrap(),
+            )
+            .unwrap();
+        })
         .to_owned();
 
-    TestRunner::default().build(&build_config, |context| {
-        assert_eq!(
-            formatdoc! {"
-                /layers/heroku_php/platform/bin/php
-                /layers/heroku_php/platform/bin/php
-                /layers/heroku_php/platform/bin/php
-            "}
-            .trim(),
-            context.run_shell_command("which -a php").stdout.trim()
-        );
-    });
+    TestRunner::default().build(&build_config, |_context| {});
 }
 
 #[test]

--- a/buildpacks/php/tests/integration/smoke.rs
+++ b/buildpacks/php/tests/integration/smoke.rs
@@ -5,9 +5,12 @@
 //!
 //! These tests are strictly happy-path tests and do not assert any output of the buildpack.
 
-use crate::utils::{builder, default_buildpacks, smoke_test, target_triple};
+use crate::utils::{builder, copy_dir_all, default_buildpacks, smoke_test, target_triple};
 use indoc::formatdoc;
 use libcnb_test::{BuildConfig, BuildpackReference, TestRunner};
+use serde_json::json;
+use std::fs;
+use std::path::PathBuf;
 
 #[test]
 #[ignore = "integration test"]
@@ -23,8 +26,40 @@ fn smoke_test_bundled_hello_world_app() {
 #[test]
 #[ignore = "integration test"]
 fn smoke_test_composer_json_scripts_as_objects() {
-    // TODO modify the composer.json to assert https://github.com/heroku/buildpacks-php/issues/81
-    let app_dir = "tests/fixtures/smoke/hello-world";
+    let temp = tempfile::tempdir().unwrap();
+    let source = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/smoke/hello-world")
+        .canonicalize()
+        .unwrap();
+    let app_dir = temp.path();
+    copy_dir_all(source, app_dir).unwrap();
+
+    let mut composer_json = serde_json::from_str::<serde_json::Map<_, _>>(
+        &fs::read_to_string(app_dir.join("composer.json")).unwrap(),
+    )
+    .unwrap();
+
+    composer_json.insert(
+        "scripts".to_string(),
+        json!({
+            "auto-scripts": {
+                "cache:clear": "echo 'cache:clear'",
+                "assets:install %PUBLIC_DIR%": "echo 'assets:install'",
+                "importmap:install": "echo 'importmap:install'"
+            },
+            "post-install-cmd": [
+                "@auto-scripts"
+            ],
+            "post-update-cmd": [
+                "@auto-scripts"
+            ]
+        }),
+    );
+    fs::write(
+        app_dir.join("composer.json"),
+        serde_json::to_string(&composer_json).unwrap(),
+    )
+    .unwrap();
 
     let build_config = BuildConfig::new(builder(), app_dir)
         .buildpacks(vec![BuildpackReference::CurrentCrate])

--- a/buildpacks/php/tests/integration/utils.rs
+++ b/buildpacks/php/tests/integration/utils.rs
@@ -2,6 +2,7 @@ use libcnb_test::{
     assert_contains, BuildConfig, BuildpackReference, ContainerConfig, TestContext, TestRunner,
 };
 use std::env;
+use std::fs::{self, DirEntry};
 use std::path::Path;
 use std::time::Duration;
 
@@ -116,4 +117,16 @@ pub(crate) fn default_buildpacks() -> Vec<BuildpackReference> {
         BuildpackReference::CurrentCrate,
         BuildpackReference::Other(String::from("heroku/procfile")),
     ]
+}
+
+pub(crate) fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Result<()> {
+    fs::create_dir_all(&dst)?;
+    for entry in fs::read_dir(src.as_ref())?.collect::<Result<Vec<DirEntry>, std::io::Error>>()? {
+        if entry.file_type()?.is_dir() {
+            copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        } else {
+            fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        }
+    }
+    Ok(())
 }

--- a/buildpacks/php/tests/integration/utils.rs
+++ b/buildpacks/php/tests/integration/utils.rs
@@ -2,7 +2,6 @@ use libcnb_test::{
     assert_contains, BuildConfig, BuildpackReference, ContainerConfig, TestContext, TestRunner,
 };
 use std::env;
-use std::fs::{self, DirEntry};
 use std::path::Path;
 use std::time::Duration;
 
@@ -117,16 +116,4 @@ pub(crate) fn default_buildpacks() -> Vec<BuildpackReference> {
         BuildpackReference::CurrentCrate,
         BuildpackReference::Other(String::from("heroku/procfile")),
     ]
-}
-
-pub(crate) fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Result<()> {
-    fs::create_dir_all(&dst)?;
-    for entry in fs::read_dir(src.as_ref())?.collect::<Result<Vec<DirEntry>, std::io::Error>>()? {
-        if entry.file_type()?.is_dir() {
-            copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
-        } else {
-            fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
-        }
-    }
-    Ok(())
 }

--- a/composer/src/lib.rs
+++ b/composer/src/lib.rs
@@ -118,8 +118,6 @@ pub struct ComposerBasePackage {
     pub repositories: Option<Vec<ComposerRepository>>,
     pub require: Option<HashMap<String, String>>,
     pub require_dev: Option<HashMap<String, String>>,
-    #[serde_as(as = "Option<HashMap<_, OneOrMany<_, PreferOne>>>")]
-    pub scripts: Option<HashMap<String, Vec<String>>>,
     pub scripts_descriptions: Option<HashMap<String, String>>,
     pub source: Option<ComposerPackageSource>,
     pub support: Option<HashMap<String, String>>,


### PR DESCRIPTION
This builds on #167. The fix is the last commit:

The previous code:

```
    #[serde_as(as = "Option<HashMap<_, OneOrMany<_, PreferOne>>>")]
    pub scripts: Option<HashMap<String, Vec<String>>>,
```

Will handle either `"scripts": {"key": "value"}` or `"scripts": {"key": ["value"]}` but not `"scripts": {"key": {"k": "v"}}`.

When json containing a map (i.e. `{}`) is parsed it fails because it is not the shape that we told serde was valid

We can fix this parse error by removing this line. By default `serde` allows serializing to a subset. i.e. if you're only expecting "name" but receive "name" and "age" it will still deserialize and quietly drop the extra information. Because the php buildpack is not using this field, we can remove it, which removes the serde error and allows tests to pass.

Close #81

GUS-W-18230376