### PR TITLE
[stacked] Remove unused composer.json fields

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,7 @@ or testing this buildpack.
 
 ### Testing
 
+- `git submodule update --init --recursive` to pull in submodules
 - `cargo test` performs Rust unit tests.
 - `cargo test -- --ignored` performs all integration tests.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,6 +495,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f89bda4c2a21204059a977ed3bfe746677dfd137b83c339e702b0ac91d482aa"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,6 +1226,7 @@ dependencies = [
  "exponential-backoff",
  "figment",
  "flate2",
+ "fs-err",
  "indoc",
  "libcnb",
  "libcnb-test",
@@ -1226,6 +1236,7 @@ dependencies = [
  "serde_json",
  "shell-words",
  "tar",
+ "tempfile",
  "ureq",
  "url",
  "warned",

--- a/buildpacks/php/CHANGELOG.md
+++ b/buildpacks/php/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The "scripts" key in `composer.json` no longer fails when provided with an object as a sub-value. ([#168](https://github.com/heroku/buildpacks-php/pull/168))
+
 ## [0.2.2] - 2025-04-03
 
 ### Changed

--- a/buildpacks/php/Cargo.toml
+++ b/buildpacks/php/Cargo.toml
@@ -12,6 +12,7 @@ composer = { path = "../../composer" }
 const_format = "0.2"
 csv = "1"
 flate2 = { version = "1", default-features = false, features = ["zlib"] }
+fs-err = "3.1.0"
 indoc = "2"
 # libcnb has a much bigger impact on buildpack behaviour than any other dependencies,
 # so it's pinned to an exact version to isolate it from lockfile refreshes.
@@ -31,3 +32,4 @@ assert-json-diff = "2"
 exponential-backoff = "1"
 figment = { version = "0.10", features = ["toml"] }
 libcnb-test = "=0.28.1"
+tempfile = "3.19.1"

--- a/buildpacks/php/src/layers/platform.rs
+++ b/buildpacks/php/src/layers/platform.rs
@@ -4,6 +4,7 @@
 use crate::utils::{self, CommandError};
 use crate::{PhpBuildpack, PhpBuildpackError};
 use composer::ComposerRootPackage;
+use fs_err::File;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
 use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
@@ -12,7 +13,6 @@ use libcnb::{Buildpack, Env, Target};
 use libherokubuildpack::log::log_info;
 use serde::de::{Error, Unexpected};
 use serde::{Deserialize, Deserializer, Serialize};
-use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 use std::process::Command;

--- a/buildpacks/php/src/main.rs
+++ b/buildpacks/php/src/main.rs
@@ -35,6 +35,8 @@ use libherokubuildpack::log::{log_error, log_header, log_info};
 use exponential_backoff as _;
 #[cfg(test)]
 use libcnb_test as _;
+#[cfg(test)]
+use tempfile as _;
 
 struct PhpBuildpack;
 

--- a/buildpacks/php/src/tests/platform/generator.rs
+++ b/buildpacks/php/src/tests/platform/generator.rs
@@ -4,9 +4,9 @@ use crate::tests::platform::ComposerLockTestCaseConfig;
 use assert_json_diff::{assert_json_matches_no_panic, CompareMode, Config};
 use figment::providers::{Format, Serialized, Toml};
 use figment::Figment;
+use fs_err as fs;
 use serde_json::{Map, Value};
 use std::collections::HashSet;
-use std::fs;
 use std::path::{Path, PathBuf};
 
 #[allow(clippy::too_many_lines)]

--- a/buildpacks/php/tests/integration/smoke.rs
+++ b/buildpacks/php/tests/integration/smoke.rs
@@ -5,8 +5,9 @@
 //!
 //! These tests are strictly happy-path tests and do not assert any output of the buildpack.
 
-use crate::utils::{builder, default_buildpacks, smoke_test};
-use libcnb_test::BuildpackReference;
+use crate::utils::{builder, default_buildpacks, smoke_test, target_triple};
+use indoc::formatdoc;
+use libcnb_test::{BuildConfig, BuildpackReference, TestRunner};
 
 #[test]
 #[ignore = "integration test"]
@@ -17,6 +18,30 @@ fn smoke_test_bundled_hello_world_app() {
         vec![BuildpackReference::CurrentCrate],
         "Hello World",
     );
+}
+
+#[test]
+#[ignore = "integration test"]
+fn smoke_test_composer_json_scripts_as_objects() {
+    // TODO modify the composer.json to assert https://github.com/heroku/buildpacks-php/issues/81
+    let app_dir = "tests/fixtures/smoke/hello-world";
+
+    let build_config = BuildConfig::new(builder(), app_dir)
+        .buildpacks(vec![BuildpackReference::CurrentCrate])
+        .target_triple(target_triple(builder()))
+        .to_owned();
+
+    TestRunner::default().build(&build_config, |context| {
+        assert_eq!(
+            formatdoc! {"
+                /layers/heroku_php/platform/bin/php
+                /layers/heroku_php/platform/bin/php
+                /layers/heroku_php/platform/bin/php
+            "}
+            .trim(),
+            context.run_shell_command("which -a php").stdout.trim()
+        );
+    });
 }
 
 #[test]

--- a/buildpacks/php/tests/integration/smoke.rs
+++ b/buildpacks/php/tests/integration/smoke.rs
@@ -42,9 +42,9 @@ fn smoke_test_composer_json_scripts_as_objects() {
         "scripts".to_string(),
         json!({
             "auto-scripts": {
-                "cache:clear": "symfony-cmd",
-                "assets:install %PUBLIC_DIR%": "symfony-cmd",
-                "importmap:install": "symfony-cmd"
+                "cache:clear": "echo 'cache:clear'",
+                "assets:install %PUBLIC_DIR%": "echo 'assets:install'",
+                "importmap:install": "echo 'importmap:install'"
             },
             "post-install-cmd": [
                 "@auto-scripts"

--- a/buildpacks/php/tests/integration/utils.rs
+++ b/buildpacks/php/tests/integration/utils.rs
@@ -1,3 +1,5 @@
+use fs::DirEntry;
+use fs_err as fs;
 use libcnb_test::{
     assert_contains, BuildConfig, BuildpackReference, ContainerConfig, TestContext, TestRunner,
 };
@@ -116,4 +118,16 @@ pub(crate) fn default_buildpacks() -> Vec<BuildpackReference> {
         BuildpackReference::CurrentCrate,
         BuildpackReference::Other(String::from("heroku/procfile")),
     ]
+}
+
+pub(crate) fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Result<()> {
+    fs::create_dir_all(&dst)?;
+    for entry in fs::read_dir(src.as_ref())?.collect::<Result<Vec<DirEntry>, std::io::Error>>()? {
+        if entry.file_type()?.is_dir() {
+            copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        } else {
+            fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        }
+    }
+    Ok(())
 }

--- a/composer/src/lib.rs
+++ b/composer/src/lib.rs
@@ -85,6 +85,10 @@ pub struct ComposerPackage {
     pub package: ComposerBasePackage,
 }
 
+/// Represents the PHP application's `composer.json`
+///
+/// Fields not specfified are quietly discarded by serde. This allows the
+/// application to have additional fields not listed below.
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -92,38 +96,12 @@ pub struct ComposerPackage {
 pub struct ComposerBasePackage {
     #[serde(rename = "type")]
     pub kind: Option<String>,
-    pub abandoned: Option<ComposerPackageAbandoned>,
-    pub archive: Option<ComposerPackageArchive>,
-    pub authors: Option<Vec<ComposerPackageAuthor>>,
-    pub autoload: Option<ComposerPackageAutoload>,
-    pub autoload_dev: Option<ComposerPackageAutoload>,
-    #[serde_as(as = "Option<OneOrMany<_, PreferOne>>")]
-    pub bin: Option<Vec<String>>,
     pub conflict: Option<HashMap<String, String>>,
-    pub description: Option<String>,
-    pub dist: Option<ComposerPackageDist>,
-    pub extra: Option<Value>,
-    pub funding: Option<Vec<ComposerPackageFunding>>,
-    pub homepage: Option<Url>,
-    pub include_path: Option<Vec<String>>,
-    pub keywords: Option<Vec<String>>,
-    #[serde_as(as = "Option<OneOrMany<_, PreferOne>>")]
-    pub license: Option<Vec<String>>,
-    pub minimum_stability: Option<ComposerStability>,
-    pub non_feature_branches: Option<Vec<String>>,
-    pub prefer_stable: Option<bool>,
     pub provide: Option<HashMap<String, String>>,
-    pub readme: Option<PathBuf>,
     pub replace: Option<HashMap<String, String>>,
     pub repositories: Option<Vec<ComposerRepository>>,
     pub require: Option<HashMap<String, String>>,
     pub require_dev: Option<HashMap<String, String>>,
-    pub scripts_descriptions: Option<HashMap<String, String>>,
-    pub source: Option<ComposerPackageSource>,
-    pub support: Option<HashMap<String, String>>,
-    pub suggest: Option<HashMap<String, String>>,
-    pub target_dir: Option<String>,
-    pub time: Option<String>, // TODO: "Package release date, in 'YYYY-MM-DD', 'YYYY-MM-DD HH:MM:SS' or 'YYYY-MM-DDTHH:MM:SSZ' format.", but in practice it uses DateTime::__construct(), which can parse a lot of formats
 }
 
 #[skip_serializing_none]

--- a/composer/src/lib.rs
+++ b/composer/src/lib.rs
@@ -118,8 +118,6 @@ pub struct ComposerBasePackage {
     pub repositories: Option<Vec<ComposerRepository>>,
     pub require: Option<HashMap<String, String>>,
     pub require_dev: Option<HashMap<String, String>>,
-    #[serde_as(as = "Option<HashMap<_, OneOrMany<_, PreferOne>>>")]
-    pub scripts: Option<HashMap<String, Vec<String>>>,
     pub scripts_descriptions: Option<HashMap<String, String>>,
     pub source: Option<ComposerPackageSource>,
     pub support: Option<HashMap<String, String>>,


### PR DESCRIPTION
The buildpack does not remove these fields, they pose a risk for a future json parse error, we can safely remove them. If needed later, only what we need can be added back in.