### PR TITLE
Remove unused scripts field - Minimal

### DIFF
--- a/composer/src/lib.rs
+++ b/composer/src/lib.rs
@@ -118,8 +118,6 @@ pub struct ComposerBasePackage {
     pub repositories: Option<Vec<ComposerRepository>>,
     pub require: Option<HashMap<String, String>>,
     pub require_dev: Option<HashMap<String, String>>,
-    #[serde_as(as = "Option<HashMap<_, OneOrMany<_, PreferOne>>>")]
-    pub scripts: Option<HashMap<String, Vec<String>>>,
     pub scripts_descriptions: Option<HashMap<String, String>>,
     pub source: Option<ComposerPackageSource>,
     pub support: Option<HashMap<String, String>>,


### PR DESCRIPTION
This is an alternative minimal fix for #168. It only has the commit that fixes the issue and no other changes.

----
The previous code:

```
    #[serde_as(as = "Option<HashMap<_, OneOrMany<_, PreferOne>>>")]
    pub scripts: Option<HashMap<String, Vec<String>>>,
```

Will handle either `"scripts": {"key": "value"}` or `"scripts": {"key": ["value"]}` but not `"scripts": {"key": {"k": "v"}}`.

When json containing a map (i.e. `{}`) is parsed it fails because it is not the shape that we told serde was valid

We can fix this parse error by removing this line. By default `serde` allows serializing to a subset. i.e. if you're only expecting "name" but receive "name" and "age" it will still deserialize and quietly drop the extra information. Because the php buildpack is not using this field, we can remove it, which removes the serde error and allows tests to pass.