### PR TITLE
Fix documentation for running tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,7 @@ or testing this buildpack.
 
 ### Testing
 
+- `git submodule update --init --recursive` to pull in submodules
 - `cargo test` performs Rust unit tests.
 - `cargo test -- --ignored` performs all integration tests.
 


### PR DESCRIPTION
The getting started guide fixture is in a submodule. Tests will fail if it's not installed.

```
$  cargo test -- --ignored
...
ERROR: failed to build: executing lifecycle: failed with status code: 20

## stdout:

Warning: Exporting to docker daemon (building without --publish) and daemon uses containerd storage; performance may be significantly degraded.
For more information, see https://github.com/buildpacks/pack/issues/2272.
===> ANALYZING
Image with name "libcnbtest_ueyvrbtamyon" not found
===> DETECTING
======== Output: heroku/php@0.2.2 ========
No PHP project files found.
======== Results ========
fail: heroku/php@0.2.2
fail: heroku/procfile@4.2.0
ERROR: No buildpack groups passed detection.
ERROR: Please check that you are running against the correct path.
ERROR: failed to detect: no buildpacks participating
```