### PR TITLE
Use fs-err everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,6 +495,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f89bda4c2a21204059a977ed3bfe746677dfd137b83c339e702b0ac91d482aa"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,6 +1226,7 @@ dependencies = [
  "exponential-backoff",
  "figment",
  "flate2",
+ "fs-err",
  "indoc",
  "libcnb",
  "libcnb-test",

--- a/buildpacks/php/CHANGELOG.md
+++ b/buildpacks/php/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix `composer.lock` parsing when "dist" key contains a `"type": "path"`. ([#176](https://github.com/heroku/buildpacks-php/pull/176))
+- All raw file system errors now include the filenames via the `fs-err` crate. ([#174](https://github.com/heroku/buildpacks-php/pull/174))
 
 ## [0.2.3] - 2025-04-08
 

--- a/buildpacks/php/Cargo.toml
+++ b/buildpacks/php/Cargo.toml
@@ -12,6 +12,7 @@ composer = { path = "../../composer" }
 const_format = "0.2"
 csv = "1"
 flate2 = { version = "1", default-features = false, features = ["zlib"] }
+fs-err = "3"
 indoc = "2"
 # libcnb has a much bigger impact on buildpack behaviour than any other dependencies,
 # so it's pinned to an exact version to isolate it from lockfile refreshes.

--- a/buildpacks/php/src/layers/platform.rs
+++ b/buildpacks/php/src/layers/platform.rs
@@ -4,6 +4,7 @@
 use crate::utils::{self, CommandError};
 use crate::{PhpBuildpack, PhpBuildpackError};
 use composer::ComposerRootPackage;
+use fs_err::File;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_content_metadata::LayerTypes;
 use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
@@ -12,7 +13,6 @@ use libcnb::{Buildpack, Env, Target};
 use libherokubuildpack::log::log_info;
 use serde::de::{Error, Unexpected};
 use serde::{Deserialize, Deserializer, Serialize};
-use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 use std::process::Command;

--- a/buildpacks/php/src/php_project.rs
+++ b/buildpacks/php/src/php_project.rs
@@ -5,10 +5,11 @@ use crate::package_manager::composer::{
 use crate::platform;
 use crate::platform::generator::{PlatformGeneratorError, PlatformJsonGeneratorInput};
 use ::composer::{ComposerLock, ComposerRootPackage};
+use fs_err as fs;
 use libcnb::Env;
 use std::collections::HashMap;
+use std::io;
 use std::path::Path;
-use std::{fs, io};
 use url::Url;
 use warned::Warned;
 

--- a/buildpacks/php/src/tests/platform/generator.rs
+++ b/buildpacks/php/src/tests/platform/generator.rs
@@ -4,9 +4,9 @@ use crate::tests::platform::ComposerLockTestCaseConfig;
 use assert_json_diff::{assert_json_matches_no_panic, CompareMode, Config};
 use figment::providers::{Format, Serialized, Toml};
 use figment::Figment;
+use fs_err as fs;
 use serde_json::{Map, Value};
 use std::collections::HashSet;
-use std::fs;
 use std::path::{Path, PathBuf};
 
 #[allow(clippy::too_many_lines)]

--- a/buildpacks/php/tests/integration/smoke.rs
+++ b/buildpacks/php/tests/integration/smoke.rs
@@ -6,9 +6,9 @@
 //! These tests are strictly happy-path tests and do not assert any output of the buildpack.
 
 use crate::utils::{builder, default_buildpacks, smoke_test, target_triple};
+use fs_err as fs;
 use libcnb_test::{BuildConfig, BuildpackReference, TestRunner};
 use serde_json::json;
-use std::fs;
 
 #[test]
 #[ignore = "integration test"]


### PR DESCRIPTION
By default `std::io::Error` which is raised by all `std::fs` calls does not emit the filename or directory where the error occured. The `fs-err` crate is a drop in replacement that adds this information.