### PR TITLE
Fix tests

### DIFF
--- a/buildpacks/php/tests/fixtures/platform/generator/path_repository/expected_platform_composer.json
+++ b/buildpacks/php/tests/fixtures/platform/generator/path_repository/expected_platform_composer.json
@@ -9,7 +9,7 @@
     "minimum-stability": "stable",
     "prefer-stable": false,
     "provide": {
-        "heroku-sys/heroku": "20.2025.04.09"
+        "heroku-sys/heroku": "20."
     },
     "repositories": [
         {


### PR DESCRIPTION
A test added yesterday started failing today due to an error:

```
 thread 'tests::platform::generator::make_platform_json_with_fixtures' panicked at buildpacks/php/src/tests/platform/generator.rs:240:13: case path_repository, key provide: json atoms at path ".heroku-sys/heroku" are not equal:
     lhs:
         "20.2025.04.10"
     rhs:
         "20.2025.04.09"
```

This comment in the test tells us what this value is for:

```rust
                        // for heroku-sys/heroku, we want to check that the generated value starts with the expected value
                        // (since the version strings are like XX.YYYY.MM.DD, with XX being the stack version number)
                        obj.entry("heroku-sys/heroku").and_modify(|exp| {
                            let gen = generated_value.get("heroku-sys/heroku").unwrap();
                            if gen.as_str().unwrap().starts_with(exp.as_str().unwrap()) {
                                *exp = gen.clone();
                            }
                        });
```

The rest of the tests list out only the first two digits which the comments indicate is the stack number:

```
$ grep 'heroku-sys\\/heroku' -R buildpacks/php/tests/fixtures/platform/generator
buildpacks/php/tests/fixtures/platform/generator/composer1/expected_platform_composer.json:        "heroku-sys\/heroku": "20."
buildpacks/php/tests/fixtures/platform/generator/mongo-php-adapter/expected_platform_composer.json:        "heroku-sys\/heroku": "20."
buildpacks/php/tests/fixtures/platform/generator/composer1.10/expected_platform_composer.json:        "heroku-sys\/heroku": "20."
buildpacks/php/tests/fixtures/platform/generator/complex/expected_platform_composer.json:        "heroku-sys\/heroku": "20."
buildpacks/php/tests/fixtures/platform/generator/provided-ext-bcmath/expected_platform_composer.json:        "heroku-sys\/heroku": "20."
buildpacks/php/tests/fixtures/platform/generator/composer2.0/expected_platform_composer.json:        "heroku-sys\/heroku": "20."
buildpacks/php/tests/fixtures/platform/generator/composer2.1/expected_platform_composer.json:        "heroku-sys\/heroku": "20."
buildpacks/php/tests/fixtures/platform/generator/customrepo/expected_platform_composer.json:        "heroku-sys\/heroku": "20."
buildpacks/php/tests/fixtures/platform/generator/stability-flags/expected_platform_composer.json:        "heroku-sys\/heroku": "20."
buildpacks/php/tests/fixtures/platform/generator/defaultphp/expected_platform_composer.json:        "heroku-sys\/heroku": "20."
buildpacks/php/tests/fixtures/platform/generator/symfony-polyfill/expected_platform_composer.json:        "heroku-sys\/heroku": "20."
buildpacks/php/tests/fixtures/platform/generator/composer2.3/expected_platform_composer.json:        "heroku-sys\/heroku": "20."
buildpacks/php/tests/fixtures/platform/generator/mycomposer.json/expected_platform_composer.json:        "heroku-sys\/heroku": "20."
buildpacks/php/tests/fixtures/platform/generator/composer2.2/expected_platform_composer.json:        "heroku-sys\/heroku": "20."
buildpacks/php/tests/fixtures/platform/generator/base/expected_platform_composer.json:        "heroku-sys\/heroku": "20."
```

This change updates the `path_repository` to only include the first two digits and a dot. Otherwise it tries to match the input value with the "start" of the expected value which is the entire thing:

```
 case: path_repository
 Gen: `"20.2025.04.10"`, exp: `"20.2025.04.09"`
```

Longer term, we should revisit this specific test logic to see if theres a more robust way we can handle changes.