### PR TITLE
Add module documentation

### DIFF
--- a/buildpacks/php/src/bootstrap.rs
+++ b/buildpacks/php/src/bootstrap.rs
@@ -1,3 +1,59 @@
+//! Installs shared build tooling
+//!
+//! > Note
+//! > Docs contain implementation details which may diverge from code.
+//!
+//! Generates two layers and downloads code into them.
+//!
+//! ## PHP minimal
+//!
+//! This version of PHP is used to ...
+//!
+//! URL: <https://lang-php.s3.us-east-1.amazonaws.com/dist-heroku-24-arm64-cnb/php-min-8.3.7.tar.gz>
+//!
+//! This artifact is downloaded into the layer directory with contents:
+//!
+//! ```shell
+//! $ exa --tree
+//! .
+//! └── bin
+//!   └── php
+//! ```
+//!
+//! This adds a version of `php` to that can be invoked for the rest of the buildpack invocation. It is
+//! not exported to other buildpacks or to the app's "launch" layer.
+//!
+//! ## PHP classic buildpack version and "installer"
+//!
+//! URL: <https://github.com/heroku/heroku-buildpack-php/archive/refs/heads/cnb-installer.tar.gz>
+//!
+//! This file comes from the `cnb-installer` branch of the <https://github.com/heroku/heroku-buildpack-php>.
+//! It represents the entirety of that branch of that repo.
+//!
+//! This artifact is downloaded and the env var `COMPOSER_HOME` is set to this path.
+//!
+//! The installed components include this "classic buildpack installer subdirectory":
+//!
+//! ```term
+//! $ ls -1 /layers/heroku_php/bootstrap_installer/support/installer
+//!
+//!   README.md
+//!   composer.json
+//!   src
+//! ```
+//!
+//! This path is returned as `platform_installer_path` which is explained in the
+//! attached readme <https://github.com/heroku/heroku-buildpack-php/blob/cnb-installer/support/installer/README.md>
+//!
+//! > It then installs a minimal PHP runtime and Composer for bootstrapping. It invokes Composer to
+//! > install the dependencies listed in the generated "platform.json", which, using this custom
+//! > Composer Installer Plugin, will cause the installation of our builds of PHP, extensions, and
+//! > programs such as the web servers - all pulled from our "platform" repository, hosted on S3.
+//! > Even Composer (the right version the user's app needs) is installed a second time by this
+//! > step, as well as any shared libraries that e.g. an extension needs (such as librdkafka for
+//! > ext-rdkafka).
+//!
+
 use crate::layers::bootstrap::BootstrapLayer;
 use crate::platform;
 use crate::PhpBuildpack;

--- a/buildpacks/php/src/layers/bootstrap.rs
+++ b/buildpacks/php/src/layers/bootstrap.rs
@@ -3,7 +3,7 @@
 //! Documenting usage outside of the current code:
 //!
 //! This layer is called twice to generate a layer path and download contents into it. See
-//! [crate::bootstrap] module docs for usage docs.
+//! [`crate::bootstrap`] module docs for usage docs.
 
 // TODO: Switch to libcnb's struct layer API.
 #![allow(deprecated)]

--- a/buildpacks/php/src/layers/bootstrap.rs
+++ b/buildpacks/php/src/layers/bootstrap.rs
@@ -1,3 +1,10 @@
+//! Downloads and extracts contents of a URL to a layer
+//!
+//! Documenting usage outside of the current code:
+//!
+//! This layer is called twice to generate a layer path and download contents into it. See
+//! [crate::bootstrap] module docs for usage docs.
+
 // TODO: Switch to libcnb's struct layer API.
 #![allow(deprecated)]
 

--- a/buildpacks/php/src/layers/composer_cache.rs
+++ b/buildpacks/php/src/layers/composer_cache.rs
@@ -1,3 +1,13 @@
+//! Creates a cache dir that composer can use
+//!
+//! Creates a directory and defines the `COMPOSER_CACHE_DIR` env var which composer
+//! uses (docs: <https://getcomposer.org/doc/03-cli.md#composer-cache-dir>).
+//!
+//! From <https://getcomposer.org/doc/06-config.md#cache-files-ttl>
+//!
+//! > Composer caches all dist (zip, tar, ...) packages that it downloads. Those are purged after
+//! > six months of being unused by default.
+
 // TODO: Switch to libcnb's struct layer API.
 #![allow(deprecated)]
 

--- a/buildpacks/php/src/layers/composer_env.rs
+++ b/buildpacks/php/src/layers/composer_env.rs
@@ -1,3 +1,18 @@
+//! Place the composer `bin-dir` on the PATH
+//!
+//! Running `composer config bin-dir` will return an output of the location of composer generated
+//! binaries. For example:
+//!
+//! ```term
+//! $ composer config bin-dir
+//! vendor/bin
+//! $ ls -1 vendor/bin
+//! heroku-php-apache2
+//! heroku-php-nginx
+//! ```
+//!
+//! The binaries from composer need to be on the `PATH` so they can be executed.
+
 // TODO: Switch to libcnb's struct layer API.
 #![allow(deprecated)]
 

--- a/buildpacks/php/src/layers/platform.rs
+++ b/buildpacks/php/src/layers/platform.rs
@@ -1,3 +1,14 @@
+//! Install dependencies
+//!
+//! Runs `composer install`. The dependencies to be installed are configured via a
+//! passed in representation of `composer.json` which is then written to the root of the layer.
+//! This functionality allow this layer to be called multiple times with different input values.
+//!
+//! For example it can be used to install "webserver" dependencies and "platform"
+//! dependencies to different layers.
+//!
+//! The result of the installation is not cached between deploys.
+
 // TODO: Switch to libcnb's struct layer API.
 #![allow(deprecated)]
 


### PR DESCRIPTION
Adds docs for all layer modules. Several of the layers are used as more of an API than for specific logic. They're being called multiple times. I felt that the bootstrap module was important to document in addition to the bootstrap layer.
