### PR TITLE
Add command information to error outputs

### DIFF
--- a/buildpacks/php/src/errors.rs
+++ b/buildpacks/php/src/errors.rs
@@ -12,7 +12,7 @@ use crate::platform::generator::{
     ComposerRepositoryFromRepositoryUrlError, PlatformGeneratorError,
 };
 use crate::platform::{PlatformRepositoryUrlError, WebserversJsonError};
-use crate::utils::{CommandError, DownloadUnpackError};
+use crate::utils::DownloadUnpackError;
 use crate::PhpBuildpackError;
 use bullet_stream::global::print;
 use const_format::formatcp;
@@ -356,13 +356,13 @@ fn on_dependency_installation_error(e: DependencyInstallationError) -> (String, 
     (
         "Failed to install dependencies".to_string(),
         match e {
-            DependencyInstallationError::InstallCommand(e) => match e {
-                CommandError::Io(e) => formatdoc! {"
+            DependencyInstallationError::ComposerInstall(e) => match e {
+                CmdError::SystemError(_, _) => formatdoc! {"
                     An unexpected error occurred during dependencies installation:
 
                     {e}
                 "},
-                CommandError::NonZeroExitStatus(_) => indoc! {"
+                _ => formatdoc! {"
                     Dependency installation failed!
 
                     The 'composer install' process failed with an error. The cause
@@ -372,6 +372,10 @@ fn on_dependency_installation_error(e: DependencyInstallationError) -> (String, 
 
                     Typical error cases are out-of-date or missing parts of code,
                     timeouts when making external connections, or memory limits.
+
+                    Details:
+
+                    {e}
 
                     Check the above error output closely to determine the cause of
                     the problem, ensure the code you're pushing is functioning

--- a/buildpacks/php/src/errors.rs
+++ b/buildpacks/php/src/errors.rs
@@ -386,19 +386,15 @@ fn on_dependency_installation_error(e: DependencyInstallationError) -> (String, 
 }
 
 fn on_composer_env_layer_error(e: ComposerEnvLayerError) -> (String, String) {
-    let heading = "Failed to prepare Composer runtime environment".to_string();
+    let heading = "Could not determine Composer 'bin-dir' config value".to_string();
     let message = match e {
-        ComposerEnvLayerError::ComposerInvoke(e) => formatdoc! {"
-            An unexpected error occurred while invoking Composer.
+        ComposerEnvLayerError::ComposerError(cmd_error) => formatdoc! {"
+            Without this value the buildpack cannot place the binaries installed by composer on the PATH
+            which is needed to run the application. The buildpack cannot continue.
 
-            Details: {e}
+            Error details:
 
-            {INTERNAL_ERROR_HELP_STRING}
-        "},
-        ComposerEnvLayerError::ComposerBinDir(e) => formatdoc! {"
-            Could not determine Composer 'bin-dir' config value.
-
-            Composer exited with status: {e}
+            {cmd_error}
 
             {INTERNAL_ERROR_HELP_STRING}
         "},

--- a/buildpacks/php/src/errors.rs
+++ b/buildpacks/php/src/errors.rs
@@ -393,7 +393,7 @@ fn on_dependency_installation_error(e: DependencyInstallationError) -> (String, 
 fn on_composer_env_layer_error(e: ComposerEnvLayerError) -> (String, String) {
     let heading = "Could not determine Composer 'bin-dir' config value".to_string();
     let message = match e {
-        ComposerEnvLayerError::ComposerError(cmd_error) => formatdoc! {"
+        ComposerEnvLayerError::BinDirConfigCmd(cmd_error) => formatdoc! {"
             Without this value, the buildpack cannot place the binaries installed by composer on the PATH,
             which is needed to run the application. The buildpack cannot continue.
 

--- a/buildpacks/php/src/errors.rs
+++ b/buildpacks/php/src/errors.rs
@@ -391,18 +391,19 @@ fn on_dependency_installation_error(e: DependencyInstallationError) -> (String, 
 }
 
 fn on_composer_env_layer_error(e: ComposerEnvLayerError) -> (String, String) {
-    let heading = "Could not determine Composer 'bin-dir' config value".to_string();
-    let message = match e {
-        ComposerEnvLayerError::BinDirConfigCmd(cmd_error) => formatdoc! {"
-            Without this value, the buildpack cannot place the binaries installed by composer on the PATH,
-            which is needed to run the application. The buildpack cannot continue.
+    match e {
+        ComposerEnvLayerError::ConfigBinDirCmd(cmd_error) => (
+            "Could not determine Composer 'bin-dir' config value".to_string(),
+            formatdoc! {"
+                Without this value, the buildpack cannot place the binaries installed by composer on the PATH,
+                which is needed to run the application. The buildpack cannot continue.
 
-            Error details:
+                Error details:
 
-            {cmd_error}
+                {cmd_error}
 
-            {INTERNAL_ERROR_HELP_STRING}
-        "},
-    };
-    (heading, message)
+                {INTERNAL_ERROR_HELP_STRING}
+            "},
+        ),
+    }
 }

--- a/buildpacks/php/src/errors.rs
+++ b/buildpacks/php/src/errors.rs
@@ -394,7 +394,7 @@ fn on_composer_env_layer_error(e: ComposerEnvLayerError) -> (String, String) {
     let heading = "Could not determine Composer 'bin-dir' config value".to_string();
     let message = match e {
         ComposerEnvLayerError::ComposerError(cmd_error) => formatdoc! {"
-            Without this value the buildpack cannot place the binaries installed by composer on the PATH
+            Without this value, the buildpack cannot place the binaries installed by composer on the PATH,
             which is needed to run the application. The buildpack cannot continue.
 
             Error details:

--- a/buildpacks/php/src/layers/composer_env.rs
+++ b/buildpacks/php/src/layers/composer_env.rs
@@ -43,7 +43,7 @@ impl Layer for ComposerEnvLayer<'_> {
                 .env("PHP_INI_SCAN_DIR", "")
                 .env("COMPOSER_AUTH", ""),
         )
-        .map_err(ComposerEnvLayerError::ComposerError)?;
+        .map_err(ComposerEnvLayerError::ConfigBinDirCmd)?;
 
         let composer_bin_dir: PathBuf = (*output.stdout_lossy().trim()).into();
         LayerResultBuilder::new(GenericMetadata::default())
@@ -63,7 +63,7 @@ impl Layer for ComposerEnvLayer<'_> {
 
 #[derive(Debug)]
 pub(crate) enum ComposerEnvLayerError {
-    ComposerError(CmdError),
+    ConfigBinDirCmd(CmdError),
 }
 
 impl From<ComposerEnvLayerError> for PhpBuildpackError {

--- a/buildpacks/php/src/layers/composer_env.rs
+++ b/buildpacks/php/src/layers/composer_env.rs
@@ -11,7 +11,7 @@ use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
 use libcnb::{Buildpack, Env};
 use std::path::{Path, PathBuf};
-use std::process::{Command, ExitStatus};
+use std::process::Command;
 
 pub(crate) struct ComposerEnvLayer<'a> {
     pub(crate) command_env: &'a Env,
@@ -43,13 +43,7 @@ impl Layer for ComposerEnvLayer<'_> {
                 .env("PHP_INI_SCAN_DIR", "")
                 .env("COMPOSER_AUTH", ""),
         )
-        .map_err(|cmd_err| match cmd_err {
-            CmdError::SystemError(_, error) => ComposerEnvLayerError::ComposerInvoke(error),
-            CmdError::NonZeroExitAlreadyStreamed(output)
-            | CmdError::NonZeroExitNotStreamed(output) => {
-                ComposerEnvLayerError::ComposerBinDir(output.status().to_owned())
-            }
-        })?;
+        .map_err(ComposerEnvLayerError::ComposerError)?;
 
         let composer_bin_dir: PathBuf = (*output.stdout_lossy().trim()).into();
         LayerResultBuilder::new(GenericMetadata::default())
@@ -69,8 +63,7 @@ impl Layer for ComposerEnvLayer<'_> {
 
 #[derive(Debug)]
 pub(crate) enum ComposerEnvLayerError {
-    ComposerInvoke(std::io::Error),
-    ComposerBinDir(ExitStatus),
+    ComposerError(CmdError),
 }
 
 impl From<ComposerEnvLayerError> for PhpBuildpackError {

--- a/buildpacks/php/src/layers/platform.rs
+++ b/buildpacks/php/src/layers/platform.rs
@@ -1,7 +1,6 @@
 // TODO: Switch to libcnb's struct layer API.
 #![allow(deprecated)]
 
-use crate::utils::CommandError;
 use crate::{PhpBuildpack, PhpBuildpackError};
 use bullet_stream::global::print;
 use composer::ComposerRootPackage;
@@ -74,14 +73,7 @@ impl Layer for PlatformLayer<'_> {
                     &provided_packages_log_file_path,
                 ),
         )
-        .map_err(|cmd_err| match cmd_err {
-            CmdError::SystemError(_, error) => CommandError::Io(error),
-            CmdError::NonZeroExitNotStreamed(named_output)
-            | CmdError::NonZeroExitAlreadyStreamed(named_output) => {
-                CommandError::NonZeroExitStatus(named_output.status().to_owned())
-            }
-        })
-        .map_err(PlatformLayerError::InstallCommand)?;
+        .map_err(PlatformLayerError::ComposerInstall)?;
         // FIXME: we have to do that now, not later, since the installer gets invoked again
         // ^ to be solved on the installer side, which has to merge the values from later calls...
 
@@ -220,7 +212,7 @@ pub(crate) enum PlatformLayerError {
     PlatformJsonWrite(serde_json::Error),
     ProvidedPackagesLogRead(csv::Error),
     ProvidedPackagesLogParse,
-    InstallCommand(CommandError),
+    ComposerInstall(CmdError),
     ReadLayerEnv(std::io::Error),
     ParseLayerEnv(serde_json::Error),
 }

--- a/buildpacks/php/src/package_manager/composer.rs
+++ b/buildpacks/php/src/package_manager/composer.rs
@@ -1,6 +1,6 @@
 use crate::platform::generator;
 use crate::platform::generator::PlatformJsonGeneratorInput;
-use crate::utils::{regex, CommandError};
+use crate::utils::regex;
 use bullet_stream::global::print;
 use composer::{
     ComposerBasePackage, ComposerLock, ComposerPackage, ComposerRepository, ComposerRootPackage,
@@ -15,7 +15,7 @@ use warned::Warned;
 
 #[derive(Debug)]
 pub(crate) enum DependencyInstallationError {
-    InstallCommand(CommandError),
+    ComposerInstall(CmdError),
 }
 
 pub(crate) fn install_dependencies(
@@ -42,14 +42,7 @@ pub(crate) fn install_dependencies(
                 //         }),
                 // ),
     )
-    .map_err(|cmd_err| match cmd_err {
-        CmdError::SystemError(_, error) => CommandError::Io(error),
-        CmdError::NonZeroExitNotStreamed(named_output)
-        | CmdError::NonZeroExitAlreadyStreamed(named_output) => {
-            CommandError::NonZeroExitStatus(named_output.status().to_owned())
-        }
-    })
-    .map_err(DependencyInstallationError::InstallCommand)?;
+    .map_err(DependencyInstallationError::ComposerInstall)?;
 
     // TODO: run `composer compile`? but is that still a good name?
 

--- a/buildpacks/php/src/utils.rs
+++ b/buildpacks/php/src/utils.rs
@@ -1,7 +1,6 @@
 use flate2::read::GzDecoder;
 use std::io;
 use std::path::{Component, Path, PathBuf};
-use std::process::ExitStatus;
 use tar::Archive;
 
 macro_rules! regex {
@@ -81,10 +80,4 @@ fn download(uri: &str) -> Result<Box<dyn io::Read + Send + Sync + 'static>, Down
         .call()
         .map_err(|err| DownloadUnpackError::Request(Box::new(err)))?
         .into_reader())
-}
-
-#[derive(Debug)]
-pub(crate) enum CommandError {
-    Io(io::Error),
-    NonZeroExitStatus(ExitStatus),
 }


### PR DESCRIPTION
- [x] An exact representation of the command being run should appear in logs, or the error, or both
- [x] Make non-zero status an error
- [x] If a command representation is output to the logs, changes to the command should be visible in the output (the display and command being run should come from a single point of truth).
- [x] Stdout and Stderr from the command should appear in logs, or the error, but NOT both (if it runs).
- [x] Stream output or print a progress indicator for commands that may take awhile or that access the network

Stacked on https://github.com/heroku/buildpacks-php/pull/171

GUS-W-18249940