### PR TITLE
State the file name being over-ridden

### DIFF
--- a/buildpacks/php/src/errors/notices.rs
+++ b/buildpacks/php/src/errors/notices.rs
@@ -14,7 +14,7 @@ fn get_message(notice: PhpBuildpackNotice) -> String {
     match notice {
         PhpBuildpackNotice::ProjectLoader(n) => match n {
             ProjectLoaderNotice::NameFromEnvVar(name, value) => formatdoc! {"
-                Environment variable '{name}={value}' is overriding default file name.
+                Environment variable '{name}={value}' is overriding default `composer.json` file name.
             "},
         },
         PhpBuildpackNotice::PlatformJson(n) => match n {


### PR DESCRIPTION
This notice is emitted when someone provides `COMPOSER=a/different/value/here.json`. With no context, it's unclear that the default file here is `composer.json` in the root if someone is inheriting a composer project and is not familiar with that env var. While they could look it up, this provides the information inline.