### PR TITLE
Support PHP 8.3 and 8.4 with `-cnb-stable` folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        builder: ["builder:24", "builder:22", "builder:20"]
+        builder: ["builder:24", "builder:22"]
         arch: ["amd64", "arm64"]
         exclude:
           - builder: "builder:22"
-            arch: "arm64"
-          - builder: "builder:20"
             arch: "arm64"
     runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-24.04-arm-medium' || 'ubuntu-24.04' }}
     env:

--- a/buildpacks/php/CHANGELOG.md
+++ b/buildpacks/php/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Stack `heroku-20` (Ubuntu 20.04) is no longer supported. ([#193](https://github.com/heroku/buildpacks-php/pull/193))
+
 ### Added
 
 - PHP 8.4 and 8.3 security updates are now available. ([#193](https://github.com/heroku/buildpacks-php/pull/193))

--- a/buildpacks/php/CHANGELOG.md
+++ b/buildpacks/php/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- PHP 8.4 and 8.3 security updates are now available. ([#193](https://github.com/heroku/buildpacks-php/pull/193))
+
 ## [1.0.1] - 2025-04-29
 
 ### Fixed

--- a/buildpacks/php/buildpack.toml
+++ b/buildpacks/php/buildpack.toml
@@ -17,10 +17,6 @@ arch = "amd64"
 
 [[targets.distros]]
 name = "ubuntu"
-version = "20.04"
-
-[[targets.distros]]
-name = "ubuntu"
 version = "22.04"
 
 [[targets.distros]]

--- a/buildpacks/php/src/platform.rs
+++ b/buildpacks/php/src/platform.rs
@@ -70,7 +70,7 @@ pub(crate) fn platform_base_url_for_target(target: &Target) -> Url {
     };
 
     Url::parse(&format!(
-        "https://lang-php.s3.us-east-1.amazonaws.com/dist-{stack_identifier}-cnb/",
+        "https://lang-php.s3.us-east-1.amazonaws.com/dist-{stack_identifier}-cnb-stable/",
     ))
     .expect("Internal error: failed to generate default repository URL")
 }

--- a/buildpacks/php/src/platform.rs
+++ b/buildpacks/php/src/platform.rs
@@ -41,7 +41,7 @@ pub(crate) fn heroku_stack_name_for_target(target: &Target) -> Result<String, St
         ..
     } = target;
     match (os.as_str(), distro_name.as_str(), distro_version.as_str()) {
-        ("linux", "ubuntu", v @ ("20.04" | "22.04" | "24.04")) => {
+        ("linux", "ubuntu", v @ ("22.04" | "24.04")) => {
             Ok(format!("heroku-{}", v.strip_suffix(".04").unwrap_or(v)))
         }
         _ => Err(format!("{os}-{distro_name}-{distro_version}")),
@@ -62,7 +62,7 @@ pub(crate) fn platform_base_url_for_target(target: &Target) -> Url {
         let stack_name = heroku_stack_name_for_target(target)
             .expect("Internal error: could not determine Heroku stack name for OS/distro");
         match v {
-            "20.04" | "22.04" => stack_name,
+            "22.04" => stack_name,
             _ => format!("{stack_name}-{arch}"),
         }
     } else {

--- a/buildpacks/php/src/tests/platform.rs
+++ b/buildpacks/php/src/tests/platform.rs
@@ -23,6 +23,7 @@ struct ComposerLockTestCaseConfig {
 
 impl Default for ComposerLockTestCaseConfig {
     fn default() -> Self {
+        // EOL Stack version used for dependency injection in test cases
         let stack = "heroku-20";
         Self {
             name: None,

--- a/buildpacks/php/tests/integration/smoke.rs
+++ b/buildpacks/php/tests/integration/smoke.rs
@@ -5,9 +5,12 @@
 //!
 //! These tests are strictly happy-path tests and do not assert any output of the buildpack.
 
-use crate::utils::{builder, default_buildpacks, smoke_test, target_triple};
+use crate::utils::{
+    builder, default_buildpacks, set_php_version, smoke_test,
+    start_container_assert_basic_http_response, target_triple,
+};
 use fs_err as fs;
-use libcnb_test::{BuildConfig, BuildpackReference, TestRunner};
+use libcnb_test::{assert_contains, BuildConfig, BuildpackReference, TestRunner};
 use serde_json::json;
 
 #[test]
@@ -19,6 +22,38 @@ fn smoke_test_bundled_hello_world_app() {
         vec![BuildpackReference::CurrentCrate],
         "Hello World",
     );
+}
+
+#[test]
+#[ignore = "integration test"]
+fn php_8_3() {
+    let version_req = "8.3.*";
+    let build_config = BuildConfig::new(builder(), "tests/fixtures/smoke/hello-world")
+        .buildpacks(vec![BuildpackReference::CurrentCrate])
+        .target_triple(target_triple(builder()))
+        .app_dir_preprocessor(move |app_dir| set_php_version(&app_dir, version_req))
+        .to_owned();
+
+    TestRunner::default().build(&build_config, |context| {
+        assert_contains!(context.run_shell_command("php --version").stdout, "PHP 8.3");
+        start_container_assert_basic_http_response(&context, "Hello World");
+    });
+}
+
+#[test]
+#[ignore = "integration test"]
+fn php_8_4() {
+    let version_req = "8.4.*";
+    let build_config = BuildConfig::new(builder(), "tests/fixtures/smoke/hello-world")
+        .buildpacks(vec![BuildpackReference::CurrentCrate])
+        .target_triple(target_triple(builder()))
+        .app_dir_preprocessor(move |app_dir| set_php_version(&app_dir, version_req))
+        .to_owned();
+
+    TestRunner::default().build(&build_config, |context| {
+        assert_contains!(context.run_shell_command("php --version").stdout, "PHP 8.4");
+        start_container_assert_basic_http_response(&context, "Hello World");
+    });
 }
 
 #[test]


### PR DESCRIPTION
The `-cnb` folder does not have PHP 8.3 security updates nor PHP 8.4. This folder has all the latest supported versions present in `-stable` except  for composer 2.2.25. 

These files were generated in action https://github.com/heroku/heroku-buildpack-php/actions/runs/14631544240 where they were pushed to `-cnb-develop` folder. They were then promoted to `-cnb-stable` folder in https://github.com/heroku/heroku-buildpack-php/actions/runs/14861974378. 

Close #145

- 8.3 security updates: GUS-W-18277407
- 8.4 support: GUS-W-17924739

The code didn’t really change, the big change was on S3. To that end, I'll gave you tips on how to inspect and print out the contents.

## Review context

The buildpack works by hosting binaries at different folders on S3. Each folder contains a `packages.json` with the current known contents of that directory. You can list them out using JQ like:

```
$ curl -s https://lang-php.s3.us-east-1.amazonaws.com/dist-heroku-24-arm64-cnb/packages.json \
    | jq '.packages["heroku-sys/php"][] | .version'
"8.2.19"
"8.2.20"
"8.2.21"
"8.2.23"
"8.2.24"
"8.2.25"
"8.3.11"
"8.3.12"
"8.3.13"
"8.3.7"
"8.3.8"
"8.3.9"
```

Notable folders:

- Classic `https://lang-php.s3.us-east-1.amazonaws.com/dist-heroku-24-arm64-stable/packages.json`
- Current CNB `https://lang-php.s3.us-east-1.amazonaws.com/dist-heroku-24-arm64-cnb/packages.json`
- Proposed updated CNB (this PR) `https://lang-php.s3.us-east-1.amazonaws.com/dist-heroku-24-arm64-cnb-stable/packages.json`

## How to review (suggestion)

- Compare versions to the latest listed on https://devcenter.heroku.com/articles/php-support.
  - The latest version should match the values in the -stable folder used by the classic buildpack
- The following contents are documented as being not available
  - blackfire
  - newrelic
  - nginx
- There are a total of 3 buckets. Heroku-22, heroku-24 ARM, and heroku-24 AMD

A blocker would be an extension that's present in `-cnb` that's either lower or missing from `-cnb-stable`. 

I performed a similar audit and found that -stable has composer "2.2.25" but -cnb and -cnb-stable both only have composer "2.2.24". I’m unsure why, but it’s not a regression, so it shouldn’t be a blocker (IMHO).