### PR TITLE
Fix git@ urls in the composer.lock

### DIFF
--- a/buildpacks/php/CHANGELOG.md
+++ b/buildpacks/php/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `composer.lock` parsing when ".packages .source .url" value starts with a `git@`. ([#194](https://github.com/heroku/buildpacks-php/pull/194))
+
 ## [1.0.3] - 2025-05-15
 
 ### Added

--- a/buildpacks/php/tests/fixtures/platform/generator/git_at_url/composer.json
+++ b/buildpacks/php/tests/fixtures/platform/generator/git_at_url/composer.json
@@ -1,0 +1,13 @@
+{
+    "repositories": [
+        {
+            "type": "git",
+            "url": "git@github.com:heroku/heroku-buildpack-php.git",
+            "no-api": true
+        }
+    ],
+    "require": {
+        "php": "8.*",
+        "heroku/heroku-buildpack-php": "*"
+    }
+}

--- a/buildpacks/php/tests/fixtures/platform/generator/git_at_url/composer.lock
+++ b/buildpacks/php/tests/fixtures/platform/generator/git_at_url/composer.lock
@@ -1,0 +1,55 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "1a2aa1a31d69ebf33962e0da2841fbe3",
+    "packages": [
+        {
+            "name": "heroku/heroku-buildpack-php",
+            "version": "v265",
+            "source": {
+                "type": "git",
+                "url": "git@github.com:heroku/heroku-buildpack-php.git",
+                "reference": "86d85038a27f17254164d68dffbbe580f5ea58ea"
+            },
+            "bin": [
+                "bin/heroku-php-apache2",
+                "bin/heroku-php-nginx"
+            ],
+            "type": "library",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Zuelke",
+                    "email": "dz@heroku.com"
+                }
+            ],
+            "description": "Toolkit for starting a PHP application locally, with or without foreman, using the same config for PHP and Apache2/Nginx as on Heroku",
+            "homepage": "https://github.com/heroku/heroku-buildpack-php",
+            "keywords": [
+                "apache",
+                "apache2",
+                "foreman",
+                "heroku",
+                "nginx",
+                "php"
+            ],
+            "time": "2025-04-11T17:06:41+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "8.*"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/buildpacks/php/tests/fixtures/platform/generator/git_at_url/expected_platform_composer.json
+++ b/buildpacks/php/tests/fixtures/platform/generator/git_at_url/expected_platform_composer.json
@@ -9,7 +9,7 @@
     "minimum-stability": "stable",
     "prefer-stable": false,
     "provide": {
-        "heroku-sys/heroku": "20.2025.05.07"
+        "heroku-sys/heroku": "20."
     },
     "repositories": [
         {

--- a/buildpacks/php/tests/fixtures/platform/generator/git_at_url/expected_platform_composer.json
+++ b/buildpacks/php/tests/fixtures/platform/generator/git_at_url/expected_platform_composer.json
@@ -1,0 +1,36 @@
+{
+    "config": {
+        "allow-plugins": {
+            "heroku/installer-plugin": true
+        },
+        "cache-files-ttl": 0,
+        "discard-changes": true
+    },
+    "minimum-stability": "stable",
+    "prefer-stable": false,
+    "provide": {
+        "heroku-sys/heroku": "20.2025.05.07"
+    },
+    "repositories": [
+        {
+            "packagist.org": false
+        },
+        {
+            "type": "path",
+            "url": "../../support/installer",
+            "options": {
+                "symlink": false
+            }
+        },
+        {
+            "type": "composer",
+            "url": "https://lang-php.s3.us-east-1.amazonaws.com/dist-heroku-20-cnb/packages.json"
+        }
+    ],
+    "require": {
+        "heroku-sys/composer-plugin-api": "^2",
+        "heroku/installer-plugin": "*",
+        "heroku-sys/composer": "*",
+        "heroku-sys/php": "8.*"
+    }
+}

--- a/composer/src/lib.rs
+++ b/composer/src/lib.rs
@@ -273,7 +273,6 @@ pub struct ComposerPackageDist {
 pub struct ComposerPackageSource {
     #[serde(rename = "type")]
     pub kind: String,
-    pub url: Url,
     pub reference: Option<String>,
     pub mirrors: Option<Vec<ComposerMirror>>,
 }


### PR DESCRIPTION
Similar to the error reported in #105 and fixed in #176 this problem is caused by strictly serializing a non-url `"git@github.com:heroku/heroku-buildpack-php.git"` into a Url type which fails to parse. The field is not used and we can discard it for now. In the future we could change it to a `String` or a `serde::json::Value` if we wish to use the field. Required behavior would dictate the direction.

The test fails without this patch and passes with it.

Fix #187

GUS-W-18352395