### PR TITLE
Fix generator test cases not executing

### DIFF
--- a/buildpacks/php/src/tests/platform/generator.rs
+++ b/buildpacks/php/src/tests/platform/generator.rs
@@ -9,7 +9,6 @@ use serde_json::{Map, Value};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-#[allow(clippy::too_many_lines)]
 #[test]
 fn make_platform_json_with_fixtures() {
     let installer_path = &PathBuf::from("../../support/installer");
@@ -30,148 +29,154 @@ fn make_platform_json_with_fixtures() {
         });
 
     for case in cases {
-        let lock = serde_json::from_str(
-            // .relative() will allow specifying the file name in the config
-            &fs::read_to_string(case.lock.as_ref().unwrap().relative()).unwrap(),
-        )
-        .unwrap();
+        assert_case(installer_path, case);
+    }
+}
 
-        // FIRST: from the lock file, extract a generator config and packages list
+#[allow(clippy::too_many_lines)]
+fn assert_case(installer_path: &Path, case: ComposerLockTestCaseConfig) {
+    let lock = serde_json::from_str(
+        // .relative() will allow specifying the file name in the config
+        &fs::read_to_string(case.lock.as_ref().unwrap().relative()).unwrap(),
+    )
+    .unwrap();
 
-        let generator_input = composer::extract_from_lock(&lock);
+    // FIRST: from the lock file, extract a generator config and packages list
 
-        // first check: was this even supposed to succeed or fail?
-        assert_eq!(
-            generator_input.is_ok(),
-            case.expect_extractor_failure.is_none(),
-            "case {}: lock extraction expected to {}, but it didn't",
-            case.name.as_ref().unwrap(),
-            if generator_input.is_ok() {
-                "fail"
-            } else {
-                "succeed"
-            },
-        );
+    let generator_input = composer::extract_from_lock(&lock);
 
-        // on failure, check if the type of failure what was the test expected
-        let mut extractor_notices = Vec::<composer::PlatformExtractorNotice>::new();
-        let generator_input = match generator_input {
-            Ok(v) => v.unwrap(&mut extractor_notices),
-            Err(e) => {
-                assert!(
+    // first check: was this even supposed to succeed or fail?
+    assert_eq!(
+        generator_input.is_ok(),
+        case.expect_extractor_failure.is_none(),
+        "case {}: lock extraction expected to {}, but it didn't",
+        case.name.as_ref().unwrap(),
+        if generator_input.is_ok() {
+            "fail"
+        } else {
+            "succeed"
+        },
+    );
+
+    // on failure, check if the type of failure what was the test expected
+    let mut extractor_notices = Vec::<composer::PlatformExtractorNotice>::new();
+    let generator_input = match generator_input {
+        Ok(v) => v.unwrap(&mut extractor_notices),
+        Err(e) => {
+            assert!(
                         case.expect_extractor_failure.is_some(),
                         "case {}: lock extraction failed, but config has no expect_extractor_failure type specified",
                         case.name.as_ref().unwrap()
                     );
 
-                assert_eq!(
-                    format!("{e:?}"),
-                    case.expect_extractor_failure.unwrap(),
-                    "case {}: lock extraction failed as expected, but with mismatched failure type",
-                    case.name.as_ref().unwrap()
-                );
+            assert_eq!(
+                format!("{e:?}"),
+                case.expect_extractor_failure.unwrap(),
+                "case {}: lock extraction failed as expected, but with mismatched failure type",
+                case.name.as_ref().unwrap()
+            );
 
-                return;
-            }
-        };
+            return;
+        }
+    };
 
-        // fetch all notices and compare them against the list of expected notices
-        assert_eq!(
-            extractor_notices
-                .iter()
-                .map(|v| format!("{v:?}"))
-                .collect::<HashSet<String>>(),
-            case.expected_extractor_notices
-                .unwrap_or_default()
-                .into_iter()
-                .collect::<HashSet<String>>(),
-            "case {}: mismatched lock extractor notices (left = generated, right = expected)",
-            case.name.as_ref().unwrap()
-        );
+    // fetch all notices and compare them against the list of expected notices
+    assert_eq!(
+        extractor_notices
+            .iter()
+            .map(|v| format!("{v:?}"))
+            .collect::<HashSet<String>>(),
+        case.expected_extractor_notices
+            .unwrap_or_default()
+            .into_iter()
+            .collect::<HashSet<String>>(),
+        "case {}: mismatched lock extractor notices (left = generated, right = expected)",
+        case.name.as_ref().unwrap()
+    );
 
-        // SECOND: generate "platform.json" from the extracted config and packages list
+    // SECOND: generate "platform.json" from the extracted config and packages list
 
-        let generated_json_package = generator::generate_platform_json(
-            &generator_input,
-            &case.stack,
-            installer_path,
-            &case.repositories,
-        );
+    let generated_json_package = generator::generate_platform_json(
+        &generator_input,
+        &case.stack,
+        installer_path,
+        &case.repositories,
+    );
 
-        // first check: was this even supposed to succeed or fail?
-        assert_eq!(
-            generated_json_package.is_ok(),
-            case.expect_generator_failure.is_none(),
-            "case {}: generation expected to {}, but it didn't",
-            case.name.as_ref().unwrap(),
-            if generated_json_package.is_ok() {
-                "fail"
-            } else {
-                "succeed"
-            },
-        );
+    // first check: was this even supposed to succeed or fail?
+    assert_eq!(
+        generated_json_package.is_ok(),
+        case.expect_generator_failure.is_none(),
+        "case {}: generation expected to {}, but it didn't",
+        case.name.as_ref().unwrap(),
+        if generated_json_package.is_ok() {
+            "fail"
+        } else {
+            "succeed"
+        },
+    );
 
-        // on failure, check if the type of failure what was the test expected
-        let mut generated_json_package = match generated_json_package {
-            Ok(v) => v,
-            Err(e) => {
-                assert!(
+    // on failure, check if the type of failure what was the test expected
+    let mut generated_json_package = match generated_json_package {
+        Ok(v) => v,
+        Err(e) => {
+            assert!(
                         case.expect_generator_failure.is_some(),
                         "case {}: generation failed, but config has no expect_generator_failure type specified",
                         case.name.as_ref().unwrap()
                     );
 
-                assert_eq!(
-                    format!("{e:?}"),
-                    case.expect_generator_failure.unwrap(),
-                    "case {}: generation failed as expected, but with mismatched failure type",
-                    case.name.as_ref().unwrap()
-                );
+            assert_eq!(
+                format!("{e:?}"),
+                case.expect_generator_failure.unwrap(),
+                "case {}: generation failed as expected, but with mismatched failure type",
+                case.name.as_ref().unwrap()
+            );
 
-                return;
-            }
-        };
+            return;
+        }
+    };
 
-        // THIRD: post-process the generated result to ensure/validate runtime requirements etc
-        let ensure_runtime_requirement_result =
-            composer::ensure_runtime_requirement(&mut generated_json_package);
+    // THIRD: post-process the generated result to ensure/validate runtime requirements etc
+    let ensure_runtime_requirement_result =
+        composer::ensure_runtime_requirement(&mut generated_json_package);
 
-        // first check: was this even supposed to succeed or fail?
-        assert_eq!(
-            ensure_runtime_requirement_result.is_ok(),
-            case.expect_finalizer_failure.is_none(),
-            "case {}: finalizing expected to {}, but it didn't",
-            case.name.as_ref().unwrap(),
-            if ensure_runtime_requirement_result.is_ok() {
-                "fail"
-            } else {
-                "succeed"
-            },
-        );
+    // first check: was this even supposed to succeed or fail?
+    assert_eq!(
+        ensure_runtime_requirement_result.is_ok(),
+        case.expect_finalizer_failure.is_none(),
+        "case {}: finalizing expected to {}, but it didn't",
+        case.name.as_ref().unwrap(),
+        if ensure_runtime_requirement_result.is_ok() {
+            "fail"
+        } else {
+            "succeed"
+        },
+    );
 
-        // on failure, check if the type of failure what was the test expected
-        let finalizer_notices = match ensure_runtime_requirement_result {
-            Ok(v) => v,
-            Err(e) => {
-                assert!(
+    // on failure, check if the type of failure what was the test expected
+    let finalizer_notices = match ensure_runtime_requirement_result {
+        Ok(v) => v,
+        Err(e) => {
+            assert!(
                         case.expect_finalizer_failure.is_some(),
                         "case {}: finalizing failed, but config has no expect_finalizer_failure type specified",
                         case.name.as_ref().unwrap()
                     );
 
-                assert_eq!(
-                    format!("{e:?}"),
-                    case.expect_finalizer_failure.unwrap(),
-                    "case {}: finalizing failed as expected, but with mismatched failure type",
-                    case.name.as_ref().unwrap()
-                );
+            assert_eq!(
+                format!("{e:?}"),
+                case.expect_finalizer_failure.unwrap(),
+                "case {}: finalizing failed as expected, but with mismatched failure type",
+                case.name.as_ref().unwrap()
+            );
 
-                return;
-            }
-        };
+            return;
+        }
+    };
 
-        // fetch all notices and compare them against the list of expected notices
-        assert_eq!(
+    // fetch all notices and compare them against the list of expected notices
+    assert_eq!(
             finalizer_notices
                 .iter()
                 .map(|v| format!("{v:?}"))
@@ -184,60 +189,59 @@ fn make_platform_json_with_fixtures() {
             name = case.name.as_ref().unwrap()
         );
 
-        if !case.install_dev {
-            // remove require-dev if we do not want dev installs
-            generated_json_package.package.require_dev.take();
-        }
+    if !case.install_dev {
+        // remove require-dev if we do not want dev installs
+        generated_json_package.package.require_dev.take();
+    }
 
-        let mut expected_json_object: Map<String, Value> = serde_json::from_str(
-            &fs::read_to_string(case.expected_result.unwrap().relative()).unwrap(),
-        )
-        .unwrap();
+    let mut expected_json_object: Map<String, Value> = serde_json::from_str(
+        &fs::read_to_string(case.expected_result.unwrap().relative()).unwrap(),
+    )
+    .unwrap();
 
-        let generated_json_value = serde_json::value::to_value(&generated_json_package).unwrap();
-        let generated_json_object = generated_json_value.as_object().unwrap();
+    let generated_json_value = serde_json::value::to_value(&generated_json_package).unwrap();
+    let generated_json_object = generated_json_value.as_object().unwrap();
 
-        let generated_keys: HashSet<String> = generated_json_object.keys().cloned().collect();
-        let expected_keys: HashSet<String> = expected_json_object.keys().cloned().collect();
+    let generated_keys: HashSet<String> = generated_json_object.keys().cloned().collect();
+    let expected_keys: HashSet<String> = expected_json_object.keys().cloned().collect();
 
-        // check if all of the expected keys are there (and only those)
-        assert_eq!(
-            &generated_keys,
-            &expected_keys,
-            "case {}: mismatched keys (left = generated, right = expected)",
-            case.name.as_ref().unwrap()
-        );
+    // check if all of the expected keys are there (and only those)
+    assert_eq!(
+        &generated_keys,
+        &expected_keys,
+        "case {}: mismatched keys (left = generated, right = expected)",
+        case.name.as_ref().unwrap()
+    );
 
-        // validate each key in the generated JSON
-        // we have to do this because we want to treat e.g. the "provide" key a bit differently
-        for key in expected_keys {
-            let generated_value = generated_json_object.get(key.as_str()).unwrap();
-            let expected_value = match key.as_str() {
-                k @ "provide" => {
-                    if let Value::Object(obj) = &mut expected_json_object.get_mut(k).unwrap() {
-                        // for heroku-sys/heroku, we want to check that the generated value starts with the expected value
-                        // (since the version strings are like XX.YYYY.MM.DD, with XX being the stack version number)
-                        obj.entry("heroku-sys/heroku").and_modify(|exp| {
-                            let gen = generated_value.get("heroku-sys/heroku").unwrap();
-                            if gen.as_str().unwrap().starts_with(exp.as_str().unwrap()) {
-                                *exp = gen.clone();
-                            }
-                        });
-                    }
-                    expected_json_object.get(k).unwrap()
+    // validate each key in the generated JSON
+    // we have to do this because we want to treat e.g. the "provide" key a bit differently
+    for key in expected_keys {
+        let generated_value = generated_json_object.get(key.as_str()).unwrap();
+        let expected_value = match key.as_str() {
+            k @ "provide" => {
+                if let Value::Object(obj) = &mut expected_json_object.get_mut(k).unwrap() {
+                    // for heroku-sys/heroku, we want to check that the generated value starts with the expected value
+                    // (since the version strings are like XX.YYYY.MM.DD, with XX being the stack version number)
+                    obj.entry("heroku-sys/heroku").and_modify(|exp| {
+                        let gen = generated_value.get("heroku-sys/heroku").unwrap();
+                        if gen.as_str().unwrap().starts_with(exp.as_str().unwrap()) {
+                            *exp = gen.clone();
+                        }
+                    });
                 }
-                // k @ "repositories" => expected_json_object.get(k).unwrap(), // maybe normalize plugin repo path, maybe sort packages in "package" repo?
-                k => expected_json_object.get(k).unwrap(),
-            };
+                expected_json_object.get(k).unwrap()
+            }
+            // k @ "repositories" => expected_json_object.get(k).unwrap(), // maybe normalize plugin repo path, maybe sort packages in "package" repo?
+            k => expected_json_object.get(k).unwrap(),
+        };
 
-            let comparison = assert_json_matches_no_panic(
-                generated_value,
-                expected_value,
-                Config::new(CompareMode::Strict),
-            )
-            .map_err(|err| format!("case {}, key {}: {}", case.name.as_ref().unwrap(), key, err));
+        let comparison = assert_json_matches_no_panic(
+            generated_value,
+            expected_value,
+            Config::new(CompareMode::Strict),
+        )
+        .map_err(|err| format!("case {}, key {}: {}", case.name.as_ref().unwrap(), key, err));
 
-            assert!(comparison.is_ok(), "{}", comparison.unwrap_err());
-        }
+        assert!(comparison.is_ok(), "{}", comparison.unwrap_err());
     }
 }

--- a/buildpacks/php/src/tests/platform/generator.rs
+++ b/buildpacks/php/src/tests/platform/generator.rs
@@ -180,8 +180,8 @@ fn make_platform_json_with_fixtures() {
                 .unwrap_or_default()
                 .into_iter()
                 .collect::<HashSet<String>>(),
-            "case {}: mismatched finalizer notices (left = generated, right = expected)",
-            case.name.as_ref().unwrap()
+            "case `{name}`: mismatched finalizer notices. Update the `{name}/config.toml` or fix the behavior. (left = generated, right = expected)",
+            name = case.name.as_ref().unwrap()
         );
 
         if !case.install_dev {


### PR DESCRIPTION
The generator tests loop through test cases on disk, however they also use `return` so the first test case that hits one of these return statements exits early and no other tests are run. This extracts the code with `return` calls in it into another function so if it returns early, the loop does not exit early.

Previously, the tests were exiting after running `require-dev-runtime-only`. You can observe this behavior by adding a print at the start and end of the new `fn assert_case`

```rust
fn assert_case(installer_path: &Path, case: ComposerLockTestCaseConfig) {
    eprintln!("Start {:?}", &case.name.as_ref().unwrap());
    // ...
    eprintln!("Done  {:?}", case.name.as_ref().unwrap());
}
```

It produces this output:

```
---- tests::platform::generator::make_platform_json_with_fixtures stdout ----
Start "composer1"
Done  "composer1"
Start "mongo-php-adapter"
Done  "mongo-php-adapter"
Start "composer1.10"
Done  "composer1.10"
Start "path_repository"
Done  "path_repository"
Start "complex"
Done  "complex"
Start "provided-ext-bcmath"
Done  "provided-ext-bcmath"
Start "composer2.0"
Done  "composer2.0"
Start "composer2.1"
Done  "composer2.1"
Start "require-dev-runtime-only"
Start "customrepo"
Done  "customrepo"
Start "stability-flags"
Done  "stability-flags"
Start "defaultphp"
Done  "defaultphp"
Start "symfony-polyfill"
Done  "symfony-polyfill"
Start "composer2.3"
Done  "composer2.3"
Start "mycomposer.json"
Done  "mycomposer.json"
Start "composer2.2"
Done  "composer2.2"
Start "base"
Done  "base"
```

Notice how some of these "start" but are never done:

```
Start "require-dev-runtime-only"
Start "customrepo"
```

I discovered this behavior when trying to generate a failure message for my last commit. When I modified the file `buildpacks/php/tests/fixtures/platform/generator/defaultphp/config.toml` to this:

```
expected_finalizer_notices = ['RuntimeRequirementInserted("php", "*")', 'thisshouldfail']
```

I expected that the tests would fail, however they didn't and I discovered that not all test cases were being executed. With this commit, my modification now makes the test suite fail (as expected):

```
 assertion `left == right` failed: case `defaultphp`: mismatched finalizer notices. Update the `defaultphp/config.toml` or fix the behavior. (left = generated, right = expected)
   left: {"RuntimeRequirementInserted(\"php\", \"*\")"}
  right: {"RuntimeRequirementInserted(\"php\", \"*\")", "thisshouldfail"}
```

The second diff is large, but I didn't change any code ... only moved it into a function.