### PR TITLE
Drop heroku-20, move to repository snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        builder: ["builder:24", "builder:22", "builder:20"]
+        builder: ["builder:24", "builder:22"]
         arch: ["amd64", "arm64"]
         exclude:
           - builder: "builder:22"
-            arch: "arm64"
-          - builder: "builder:20"
             arch: "arm64"
     runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-24.04-arm-medium' || 'ubuntu-24.04' }}
     env:

--- a/buildpacks/php/CHANGELOG.md
+++ b/buildpacks/php/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Drop support for heroku-20 ([#197](https://github.com/heroku/buildpacks-php/pull/197))
 - Use repository snapshots for platform packages ([#197](https://github.com/heroku/buildpacks-php/pull/197))
 
+### Fixed
+
+- Installation of multiple "polyfill" packages fails due to reused Command struct ([#197](https://github.com/heroku/buildpacks-php/pull/197))
+
 ## [1.0.1] - 2025-04-29
 
 ### Fixed

--- a/buildpacks/php/CHANGELOG.md
+++ b/buildpacks/php/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Drop support for heroku-20 ([#197](https://github.com/heroku/buildpacks-php/pull/197))
+- Use repository snapshots for platform packages ([#197](https://github.com/heroku/buildpacks-php/pull/197))
 
 ## [1.0.1] - 2025-04-29
 

--- a/buildpacks/php/CHANGELOG.md
+++ b/buildpacks/php/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Drop support for heroku-20 ([#197](https://github.com/heroku/buildpacks-php/pull/197))
+
 ## [1.0.1] - 2025-04-29
 
 ### Fixed

--- a/buildpacks/php/buildpack.toml
+++ b/buildpacks/php/buildpack.toml
@@ -17,10 +17,6 @@ arch = "amd64"
 
 [[targets.distros]]
 name = "ubuntu"
-version = "20.04"
-
-[[targets.distros]]
-name = "ubuntu"
 version = "22.04"
 
 [[targets.distros]]

--- a/buildpacks/php/src/bootstrap.rs
+++ b/buildpacks/php/src/bootstrap.rs
@@ -7,8 +7,10 @@ use libcnb::layer_env::Scope;
 use libcnb::Env;
 use std::path::PathBuf;
 
-const PHP_VERSION: &str = "8.3.7";
-const COMPOSER_VERSION: &str = "2.7.6";
+#[rustfmt::skip]
+pub(crate) const PLATFORM_REPOSITORY_SNAPSHOT: &str = "0663fcbbafa27cdb33633013afc65133cd684257d160d9d9db49c1f64b49c024";
+const PHP_VERSION: &str = "8.3.20";
+const COMPOSER_VERSION: &str = "2.8.8";
 const CLASSIC_BUILDPACK_VERSION: &str = "heads/cnb-installer";
 const CLASSIC_BUILDPACK_INSTALLER_SUBDIR: &str = "support/installer";
 

--- a/buildpacks/php/src/platform.rs
+++ b/buildpacks/php/src/platform.rs
@@ -1,5 +1,6 @@
 pub(crate) mod generator;
 
+use crate::bootstrap;
 use crate::platform::generator::PlatformGeneratorError;
 use crate::PhpBuildpack;
 use composer::ComposerRootPackage;
@@ -70,7 +71,7 @@ pub(crate) fn platform_base_url_for_target(target: &Target) -> Url {
     };
 
     Url::parse(&format!(
-        "https://lang-php.s3.us-east-1.amazonaws.com/dist-{stack_identifier}-cnb/",
+        "https://lang-php.s3.us-east-1.amazonaws.com/dist-{stack_identifier}-cnb-stable/",
     ))
     .expect("Internal error: failed to generate default repository URL")
 }
@@ -84,7 +85,9 @@ pub(crate) fn platform_repository_urls_from_default_and_build_context(
     context: &BuildContext<PhpBuildpack>,
 ) -> Result<Vec<Url>, PlatformRepositoryUrlError> {
     // our default repo
-    let default_platform_repositories = vec![platform_base_url_for_target(&context.target)];
+    let default_platform_repositories = vec![platform_base_url_for_target(&context.target)
+        .join(format!("packages-{}.json", bootstrap::PLATFORM_REPOSITORY_SNAPSHOT).as_str())
+        .expect("Internal error: failed to generate default repository URL")];
 
     // anything user-supplied
     let user_repos = context

--- a/buildpacks/php/src/platform.rs
+++ b/buildpacks/php/src/platform.rs
@@ -41,7 +41,7 @@ pub(crate) fn heroku_stack_name_for_target(target: &Target) -> Result<String, St
         ..
     } = target;
     match (os.as_str(), distro_name.as_str(), distro_version.as_str()) {
-        ("linux", "ubuntu", v @ ("20.04" | "22.04" | "24.04")) => {
+        ("linux", "ubuntu", v @ ("22.04" | "24.04")) => {
             Ok(format!("heroku-{}", v.strip_suffix(".04").unwrap_or(v)))
         }
         _ => Err(format!("{os}-{distro_name}-{distro_version}")),
@@ -62,7 +62,7 @@ pub(crate) fn platform_base_url_for_target(target: &Target) -> Url {
         let stack_name = heroku_stack_name_for_target(target)
             .expect("Internal error: could not determine Heroku stack name for OS/distro");
         match v {
-            "20.04" | "22.04" => stack_name,
+            "22.04" => stack_name,
             _ => format!("{stack_name}-{arch}"),
         }
     } else {

--- a/buildpacks/php/tests/fixtures/smoke/polyfills/composer.json
+++ b/buildpacks/php/tests/fixtures/smoke/polyfills/composer.json
@@ -1,0 +1,22 @@
+{
+	"require": {
+		"php": "8.4.*",
+		"ext-soap": "*",
+		"ext-redis": "*",
+		"ext-intl": "*",
+		"ext-imagick": "*",
+		"ext-bcmath": "*",
+		"ext-oauth": "*",
+		"ext-gd": "*",
+		"ext-mbstring": "*",
+		"ext-iconv": "*",
+		"ext-ctype": "*",
+		"symfony/polyfill-ctype": "*",
+		"symfony/polyfill-mbstring": "*",
+		"phpseclib/mcrypt_compat": "*",
+		"ext-mcrypt": "*"
+	},
+	"require-dev": {
+		"heroku/heroku-buildpack-php": "*"
+	}
+}

--- a/buildpacks/php/tests/fixtures/smoke/polyfills/composer.lock
+++ b/buildpacks/php/tests/fixtures/smoke/polyfills/composer.lock
@@ -1,0 +1,533 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "ccf8821d60938f6bf38a6dd64364bcc0",
+    "packages": [
+        {
+            "name": "paragonie/constant_time_encoding",
+            "version": "v3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/constant_time_encoding.git",
+                "reference": "df1e7fde177501eee2037dd159cf04f5f301a512"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/df1e7fde177501eee2037dd159cf04f5f301a512",
+                "reference": "df1e7fde177501eee2037dd159cf04f5f301a512",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9",
+                "vimeo/psalm": "^4|^5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ParagonIE\\ConstantTime\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Steve 'Sc00bz' Thomas",
+                    "email": "steve@tobtu.com",
+                    "homepage": "https://www.tobtu.com",
+                    "role": "Original Developer"
+                }
+            ],
+            "description": "Constant-time Implementations of RFC 4648 Encoding (Base-64, Base-32, Base-16)",
+            "keywords": [
+                "base16",
+                "base32",
+                "base32_decode",
+                "base32_encode",
+                "base64",
+                "base64_decode",
+                "base64_encode",
+                "bin2hex",
+                "encoding",
+                "hex",
+                "hex2bin",
+                "rfc4648"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/constant_time_encoding/issues",
+                "source": "https://github.com/paragonie/constant_time_encoding"
+            },
+            "time": "2024-05-08T12:36:18+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v9.99.100",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "polyfill",
+                "pseudorandom",
+                "random"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/random_compat/issues",
+                "source": "https://github.com/paragonie/random_compat"
+            },
+            "time": "2020-10-15T08:29:30+00:00"
+        },
+        {
+            "name": "phpseclib/mcrypt_compat",
+            "version": "2.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpseclib/mcrypt_compat.git",
+                "reference": "e5924504997b4f90772034cefd89dc2f4ec189dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpseclib/mcrypt_compat/zipball/e5924504997b4f90772034cefd89dc2f4ec189dc",
+                "reference": "e5924504997b4f90772034cefd89dc2f4ec189dc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.1",
+                "phpseclib/phpseclib": ">=3.0.36 <4.0.0"
+            },
+            "provide": {
+                "ext-mcrypt": "5.6.40"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7|^6.0|^9.4"
+            },
+            "suggest": {
+                "ext-openssl": "Will enable faster cryptographic operations"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/mcrypt.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jim Wigginton",
+                    "email": "terrafrost@php.net",
+                    "homepage": "http://phpseclib.sourceforge.net"
+                }
+            ],
+            "description": "PHP 5.x-8.x polyfill for mcrypt extension",
+            "keywords": [
+                "cryptograpy",
+                "encryption",
+                "mcrypt",
+                "polyfill"
+            ],
+            "support": {
+                "email": "terrafrost@php.net",
+                "issues": "https://github.com/phpseclib/mcrypt_compat/issues",
+                "source": "https://github.com/phpseclib/mcrypt_compat"
+            },
+            "funding": [
+                {
+                    "url": "https://www.patreon.com/phpseclib",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpseclib/mcrypt_compat",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-02-26T14:52:18+00:00"
+        },
+        {
+            "name": "phpseclib/phpseclib",
+            "version": "3.0.43",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpseclib/phpseclib.git",
+                "reference": "709ec107af3cb2f385b9617be72af8cf62441d02"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/709ec107af3cb2f385b9617be72af8cf62441d02",
+                "reference": "709ec107af3cb2f385b9617be72af8cf62441d02",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/constant_time_encoding": "^1|^2|^3",
+                "paragonie/random_compat": "^1.4|^2.0|^9.99.99",
+                "php": ">=5.6.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "suggest": {
+                "ext-dom": "Install the DOM extension to load XML formatted public keys.",
+                "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
+                "ext-libsodium": "SSH2/SFTP can make use of some algorithms provided by the libsodium-php extension.",
+                "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
+                "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "phpseclib/bootstrap.php"
+                ],
+                "psr-4": {
+                    "phpseclib3\\": "phpseclib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jim Wigginton",
+                    "email": "terrafrost@php.net",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Patrick Monnerat",
+                    "email": "pm@datasphere.ch",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Andreas Fischer",
+                    "email": "bantu@phpbb.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Hans-Jürgen Petrich",
+                    "email": "petrich@tronic-media.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Secure Communications Library - Pure-PHP implementations of RSA, AES, SSH2, SFTP, X.509 etc.",
+            "homepage": "http://phpseclib.sourceforge.net",
+            "keywords": [
+                "BigInteger",
+                "aes",
+                "asn.1",
+                "asn1",
+                "blowfish",
+                "crypto",
+                "cryptography",
+                "encryption",
+                "rsa",
+                "security",
+                "sftp",
+                "signature",
+                "signing",
+                "ssh",
+                "twofish",
+                "x.509",
+                "x509"
+            ],
+            "support": {
+                "issues": "https://github.com/phpseclib/phpseclib/issues",
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.43"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/terrafrost",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpseclib",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpseclib/phpseclib",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-12-14T21:12:59+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.32.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.32.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.32.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.32.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-12-23T08:48:59+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "heroku/heroku-buildpack-php",
+            "version": "v265",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/heroku/heroku-buildpack-php.git",
+                "reference": "86d85038a27f17254164d68dffbbe580f5ea58ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/heroku/heroku-buildpack-php/zipball/86d85038a27f17254164d68dffbbe580f5ea58ea",
+                "reference": "86d85038a27f17254164d68dffbbe580f5ea58ea",
+                "shasum": ""
+            },
+            "bin": [
+                "bin/heroku-php-apache2",
+                "bin/heroku-php-nginx"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Zuelke",
+                    "email": "dz@heroku.com"
+                }
+            ],
+            "description": "Toolkit for starting a PHP application locally, with or without foreman, using the same config for PHP and Apache2/Nginx as on Heroku",
+            "homepage": "https://github.com/heroku/heroku-buildpack-php",
+            "keywords": [
+                "apache",
+                "apache2",
+                "foreman",
+                "heroku",
+                "nginx",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/heroku/heroku-buildpack-php/issues",
+                "source": "https://github.com/heroku/heroku-buildpack-php/tree/v265"
+            },
+            "time": "2025-04-11T17:06:41+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "8.4.*",
+        "ext-soap": "*",
+        "ext-redis": "*",
+        "ext-intl": "*",
+        "ext-imagick": "*",
+        "ext-bcmath": "*",
+        "ext-oauth": "*",
+        "ext-gd": "*",
+        "ext-mbstring": "*",
+        "ext-iconv": "*",
+        "ext-ctype": "*",
+        "ext-mcrypt": "*"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/buildpacks/php/tests/integration/smoke.rs
+++ b/buildpacks/php/tests/integration/smoke.rs
@@ -70,3 +70,14 @@ fn smoke_test_php_getting_started() {
         "Getting Started with PHP on Heroku",
     );
 }
+
+#[test]
+#[ignore = "integration test"]
+fn smoke_test_php_polyfills() {
+    let build_config = BuildConfig::new(builder(), "tests/fixtures/smoke/polyfills")
+        .buildpacks(vec![BuildpackReference::CurrentCrate])
+        .target_triple(target_triple(builder()))
+        .to_owned();
+
+    TestRunner::default().build(&build_config, |_context| {});
+}


### PR DESCRIPTION
Drops support for heroku-20, and moves to repository snapshots with up-to-date platform packages.

Also fixes an issue with polyfill installs.

GUS-W-14707054
GUS-W-17924739
GUS-W-18259232
GUS-W-18277407
GUS-W-18505832