### PR TITLE
Assert polyfill smoke command invocations

### DIFF
--- a/buildpacks/php/tests/integration/smoke.rs
+++ b/buildpacks/php/tests/integration/smoke.rs
@@ -7,7 +7,7 @@
 
 use crate::utils::{builder, default_buildpacks, smoke_test, target_triple};
 use fs_err as fs;
-use libcnb_test::{BuildConfig, BuildpackReference, TestRunner};
+use libcnb_test::{assert_contains, BuildConfig, BuildpackReference, TestRunner};
 use serde_json::json;
 
 #[test]
@@ -79,5 +79,9 @@ fn smoke_test_php_polyfills() {
         .target_triple(target_triple(builder()))
         .to_owned();
 
-    TestRunner::default().build(&build_config, |_context| {});
+    TestRunner::default().build(&build_config, |context| {
+        assert_contains!(context.pack_stderr, r#"composer require "heroku-sys/ext-mcrypt.native:*""#);
+        assert_contains!(context.pack_stderr, r#"composer require "heroku-sys/ext-ctype.native:*""#);
+        assert_contains!(context.pack_stderr, r#"composer require "heroku-sys/ext-mbstring.native:*""#);
+    });
 }


### PR DESCRIPTION
The prior bug that this test is designed to exercise resulted in commands like this:

```
  - Running `composer require "heroku-sys/ext-mcrypt.native:*" require "heroku-sys/ext-ctype.native:*" require "heroku-sys/ext-mbstring.native:*"`
```

When it should be three separate `composer require` executions:

```
  - Running `composer require "heroku-sys/ext-mcrypt.native:*"`
...
  - Running `composer require "heroku-sys/ext-ctype.native:*"`
...
  - Running `composer require "heroku-sys/ext-mbstring.native:*"`
```

This test fails before the patch was introduced in https://github.com/heroku/buildpacks-php/pull/197 and passes after it.