### PR TITLE
May 2025 PHP updates

### DIFF
--- a/buildpacks/php/CHANGELOG.md
+++ b/buildpacks/php/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- PHP/8.3.21
+- PHP/8.4.7
+- ext-phalcon/5.9.3
+- ext-grpc/1.72.0
+- ext-uuid/1.3.0
+- librdkafka/2.10.0
+- Nginx/1.28.0
+- Composer/2.8.9
+
 ## [1.0.2] - 2025-05-13
 
 ### Changed

--- a/buildpacks/php/CHANGELOG.md
+++ b/buildpacks/php/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Nginx/1.28.0
 - Composer/2.8.9
 
+### Fixed
+
+- Nginx fails to start ([#186](https://github.com/heroku/buildpacks-php/issues/186))
+
 ## [1.0.2] - 2025-05-13
 
 ### Changed

--- a/buildpacks/php/src/bootstrap.rs
+++ b/buildpacks/php/src/bootstrap.rs
@@ -8,9 +8,9 @@ use libcnb::Env;
 use std::path::PathBuf;
 
 #[rustfmt::skip]
-pub(crate) const PLATFORM_REPOSITORY_SNAPSHOT: &str = "0663fcbbafa27cdb33633013afc65133cd684257d160d9d9db49c1f64b49c024";
-const PHP_VERSION: &str = "8.3.20";
-const COMPOSER_VERSION: &str = "2.8.8";
+pub(crate) const PLATFORM_REPOSITORY_SNAPSHOT: &str = "894e3bbddf921e1903df9d64356fac8a04feacb5339d0b171e27d57b0fbf8bd5";
+const PHP_VERSION: &str = "8.3.21";
+const COMPOSER_VERSION: &str = "2.8.9";
 const CLASSIC_BUILDPACK_VERSION: &str = "heads/cnb-installer";
 const CLASSIC_BUILDPACK_INSTALLER_SUBDIR: &str = "support/installer";
 

--- a/buildpacks/php/tests/integration/smoke.rs
+++ b/buildpacks/php/tests/integration/smoke.rs
@@ -5,7 +5,10 @@
 //!
 //! These tests are strictly happy-path tests and do not assert any output of the buildpack.
 
-use crate::utils::{builder, default_buildpacks, smoke_test, target_triple};
+use crate::utils::{
+    builder, default_buildpacks, smoke_test, start_container_assert_basic_http_response,
+    target_triple,
+};
 use fs_err as fs;
 use libcnb_test::{BuildConfig, BuildpackReference, TestRunner};
 use serde_json::json;
@@ -19,6 +22,22 @@ fn smoke_test_bundled_hello_world_app() {
         vec![BuildpackReference::CurrentCrate],
         "Hello World",
     );
+}
+
+#[test]
+#[ignore = "integration test"]
+fn smoke_test_php_nginx() {
+    let build_config = BuildConfig::new(builder(), "tests/fixtures/smoke/hello-world")
+        .buildpacks(vec![BuildpackReference::CurrentCrate])
+        .target_triple(target_triple(builder()))
+        .app_dir_preprocessor(|app_dir| {
+            fs::write(app_dir.join("Procfile"), "web: heroku-php-nginx").unwrap();
+        })
+        .to_owned();
+
+    TestRunner::default().build(&build_config, |context| {
+        start_container_assert_basic_http_response(&context, "Hello World");
+    });
 }
 
 #[test]

--- a/buildpacks/php/tests/integration/utils.rs
+++ b/buildpacks/php/tests/integration/utils.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 ///a
 /// The smoke integration tests need to ensure the container runs as expected.
 /// This function is catering to that use-case and is not useful in other contexts.
-fn start_container_assert_basic_http_response(
+pub(crate) fn start_container_assert_basic_http_response(
     context: &TestContext,
     expected_http_response_body_contains: &str,
 ) {


### PR DESCRIPTION
[Updated platform package repository snapshot](https://github.com/heroku/heroku-buildpack-php/actions/runs/15031915718) with the following new packages:
- PHP/8.3.21
- PHP/8.4.7
- ext-phalcon/5.9.3
- ext-grpc/1.72.0
- ext-uuid/1.3.0
- librdkafka/2.10.0
- Nginx/1.28.0
- Composer/2.8.9

Also fixes #186 (Nginx fails to start).

GUS-W-18521550
GUS-W-13169735