### PR TITLE
Fix make_platform_json_with_fixtures test loop terminating early

### DIFF
--- a/buildpacks/php/src/tests/platform/generator.rs
+++ b/buildpacks/php/src/tests/platform/generator.rs
@@ -71,7 +71,9 @@ fn make_platform_json_with_fixtures() {
                     case.name.as_ref().unwrap()
                 );
 
-                return;
+                // if we're here, then the case was expected to fail at this step
+                // no point in continuing any further; skip ahead to the next case
+                continue;
             }
         };
 
@@ -128,7 +130,9 @@ fn make_platform_json_with_fixtures() {
                     case.name.as_ref().unwrap()
                 );
 
-                return;
+                // if we're here, then the case was expected to fail at this step
+                // no point in continuing any further; skip ahead to the next case
+                continue;
             }
         };
 
@@ -166,7 +170,9 @@ fn make_platform_json_with_fixtures() {
                     case.name.as_ref().unwrap()
                 );
 
-                return;
+                // if we're here, then the case was expected to fail at this step
+                // no point in continuing any further; skip ahead to the next case
+                continue;
             }
         };
 


### PR DESCRIPTION
Spotted by @schneems in #195. The return statement aborts the for loop, but the intention was to skip ahead to the next case instead.