### PR TITLE
Support object for 'repositories' key in composer.json

### DIFF
--- a/buildpacks/php/CHANGELOG.md
+++ b/buildpacks/php/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Retry downloads during bootstrapping ([#226](https://github.com/heroku/buildpacks-php/pull/226))
 - Consistent handling of "non-URL" URLs (SSH-style or path) in `composer.json`/`composer.lock` repositories and package `source`s/`dist`s ([#105](https://github.com/heroku/buildpacks-php/issue/105), [#187](https://github.com/heroku/buildpacks-php/issue/187), [#208](https://github.com/heroku/buildpacks-php/pull/208))
+- Support object-style notation of repositories in composer.json ([#209](https://github.com/heroku/buildpacks-php/pull/209))
 
 ## [1.0.6] - 2025-07-31
 

--- a/buildpacks/php/src/package_manager/composer.rs
+++ b/buildpacks/php/src/package_manager/composer.rs
@@ -251,19 +251,20 @@ pub(crate) fn ensure_runtime_requirement(
 ) -> Result<Vec<PlatformFinalizerNotice>, PlatformFinalizerError> {
     let mut notices = Vec::new();
 
-    // from all our metapackages, dev or not, make a lookup table
-    let metapackages = root_package
+    let repositories = root_package
         .package
         .repositories
         .clone()
-        .unwrap_or_default()
-        .into_iter()
+        .unwrap_or_default();
+    // from all our metapackages, dev or not, make a lookup table
+    let metapackages = repositories
+        .iter()
         .filter(|repo| matches!(repo, ComposerRepository::Package { .. }))
         .fold(HashMap::new(), |mut acc, repo| match repo {
             ComposerRepository::Package { package, .. } => {
                 acc.extend(
                     package
-                        .into_iter()
+                        .iter()
                         .map(|package| (package.name.clone(), package)),
                 );
                 acc

--- a/buildpacks/php/src/platform/generator.rs
+++ b/buildpacks/php/src/platform/generator.rs
@@ -301,7 +301,7 @@ pub(crate) fn generate_platform_json(
         package: ComposerBasePackage {
             provide: Some(HashMap::from([stack_provide])),
             replace: None, // TODO: blackfire
-            repositories: Some(ComposerRepositories::Array(repositories)),
+            repositories: Some(ComposerRepositories::from(repositories)),
             require: (!require.is_empty()).then_some(require),
             require_dev: (!require_dev.is_empty()).then_some(require_dev),
             ..Default::default()

--- a/buildpacks/php/src/platform/generator.rs
+++ b/buildpacks/php/src/platform/generator.rs
@@ -191,11 +191,7 @@ pub(crate) fn generate_platform_json(
 
     // disable packagist.org (we want to userland package installs here), and add the installer plugin
     let mut repositories = vec![
-        ComposerRepository::Disabled(
-            "packagist.org"
-                .parse()
-                .expect("Internal error: ComposerRepositoryDisablement construction"),
-        ),
+        ComposerRepository::Disabled("packagist.org".into()),
         // our heroku/installer-plugin
         ComposerRepository::from_path_with_options(
             installer_path,

--- a/buildpacks/php/src/platform/generator.rs
+++ b/buildpacks/php/src/platform/generator.rs
@@ -191,8 +191,11 @@ pub(crate) fn generate_platform_json(
 
     // disable packagist.org (we want to userland package installs here), and add the installer plugin
     let mut repositories = vec![
-        serde_json::from_value(json!({"packagist.org": false}))
-            .expect("Internal error: repository construction via serde_json"),
+        ComposerRepository::Disabled(
+            "packagist.org"
+                .parse()
+                .expect("Internal error: ComposerRepositoryDisablement construction"),
+        ),
         // our heroku/installer-plugin
         ComposerRepository::from_path_with_options(
             installer_path,

--- a/buildpacks/php/src/platform/generator.rs
+++ b/buildpacks/php/src/platform/generator.rs
@@ -2,7 +2,7 @@ use crate::package_manager;
 use crate::utils::regex;
 use chrono::offset::Utc;
 use composer::{
-    ComposerBasePackage, ComposerLock, ComposerPackage, ComposerRepository,
+    ComposerBasePackage, ComposerLock, ComposerPackage, ComposerRepositories, ComposerRepository,
     ComposerRepositoryFilters, ComposerRootPackage, ComposerStability,
 };
 use serde_json::json;
@@ -302,7 +302,7 @@ pub(crate) fn generate_platform_json(
         package: ComposerBasePackage {
             provide: Some(HashMap::from([stack_provide])),
             replace: None, // TODO: blackfire
-            repositories: Some(repositories),
+            repositories: Some(ComposerRepositories::Array(repositories)),
             require: (!require.is_empty()).then_some(require),
             require_dev: (!require_dev.is_empty()).then_some(require_dev),
             ..Default::default()

--- a/composer/src/lib.rs
+++ b/composer/src/lib.rs
@@ -601,18 +601,6 @@ mod tests {
         );
     }
 
-    #[rstest]
-    fn test_composer_json(#[files("tests/fixtures/*.json")] path: PathBuf) {
-        let composer_json = fs::read(&path).unwrap();
-        serde_json::from_slice::<ComposerRootPackage>(&composer_json).unwrap();
-    }
-
-    #[rstest]
-    fn test_composer_lock(#[files("tests/fixtures/*.lock")] path: PathBuf) {
-        let composer_lock = fs::read(&path).unwrap();
-        serde_json::from_slice::<ComposerLock>(&composer_lock).unwrap();
-    }
-
     #[test]
     fn test_php_assoc_array_empty() {
         assert_de_tokens(
@@ -635,5 +623,17 @@ mod tests {
             &[Token::Seq { len: Some(1) }, Token::U8(42), Token::SeqEnd],
             "sequence must be empty",
         );
+    }
+
+    #[rstest]
+    fn test_composer_json(#[files("tests/fixtures/*.json")] path: PathBuf) {
+        let composer_json = fs::read(&path).unwrap();
+        serde_json::from_slice::<ComposerRootPackage>(&composer_json).unwrap();
+    }
+
+    #[rstest]
+    fn test_composer_lock(#[files("tests/fixtures/*.lock")] path: PathBuf) {
+        let composer_lock = fs::read(&path).unwrap();
+        serde_json::from_slice::<ComposerLock>(&composer_lock).unwrap();
     }
 }

--- a/composer/src/lib.rs
+++ b/composer/src/lib.rs
@@ -9,7 +9,6 @@ use std::collections::HashMap;
 use std::fmt;
 use std::marker::PhantomData;
 use std::path::PathBuf;
-use std::str::FromStr;
 use url::Url;
 
 #[derive(Clone, Debug, Default, Deref, From, PartialEq, Serialize)]
@@ -466,13 +465,9 @@ pub enum ComposerRepositoryDisablement {
     Object(HashMap<String, MustBe!(false)>), // a (single-field) object like {"packagist.org": false}
 }
 
-impl FromStr for ComposerRepositoryDisablement {
-    type Err = String;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(ComposerRepositoryDisablement::Object(HashMap::from([(
-            s.to_string(),
-            MustBe!(false),
-        )])))
+impl From<&str> for ComposerRepositoryDisablement {
+    fn from(s: &str) -> Self {
+        ComposerRepositoryDisablement::Object(HashMap::from([(s.to_string(),MustBe!(false))]))
     }
 }
 

--- a/composer/src/lib.rs
+++ b/composer/src/lib.rs
@@ -37,7 +37,7 @@ impl<'de, T: Deserialize<'de> + Default> Deserialize<'de> for PhpAssocArray<T> {
                 A: SeqAccess<'de>,
             {
                 match seq.next_element::<T>() {
-                    Ok(Some(_)) | Err(_) => Err(A::Error::custom("sequence must be empty")), // if a T is in there or something else is in there
+                    Ok(Some(_)) | Err(_) => Err(Error::custom("sequence must be empty")), // if a T is in there or something else is in there
                     Ok(None) => Ok(PhpAssocArray::default()),
                 }
             }

--- a/composer/tests/fixtures/composer-repositoriesasobject.json
+++ b/composer/tests/fixtures/composer-repositoriesasobject.json
@@ -4,9 +4,11 @@
         "While rare and not recommended (because repository order is significant for package lookups)",
         "it's what Composer generates when using the CLI to modify or disable a repository (e.g. 'packagist.org').",
         "See https://getcomposer.org/doc/04-schema.md#repositories",
+        "When specifying repositories in this form, an existing repository is disabled using a simple false value.",
         "A lock file is not needed for this case."
     ],
     "repositories": {
+        "packagist.org": false,
         "inline": {
             "type": "package",
             "package": [

--- a/composer/tests/fixtures/composer-repositoriesasobject.json
+++ b/composer/tests/fixtures/composer-repositoriesasobject.json
@@ -1,0 +1,24 @@
+{
+    "_comment": [
+        "This is a test fixture covering the repositories key being an object instead of the more common array.",
+        "While rare and not recommended (because repository order is significant for package lookups)",
+        "it's what Composer generates when using the CLI to modify or disable a repository (e.g. 'packagist.org').",
+        "See https://getcomposer.org/doc/04-schema.md#repositories",
+        "A lock file is not needed for this case."
+    ],
+    "repositories": {
+        "inline": {
+            "type": "package",
+            "package": [
+                {
+                    "name": "my/package",
+                    "type": "metapackage",
+                    "version": "1.0.0"
+                }
+            ]
+        }
+    },
+    "require": {
+        "my/package": "^1.0.0"
+    }
+}


### PR DESCRIPTION
Custom repositories are typically listed in a composer.json file using an array, see https://getcomposer.org/doc/04-schema.md#repositories.

This is the recommended way, because repositories are used in the specified order: https://getcomposer.org/doc/articles/repository-priorities.md

There is an alternative notation for repositories, where they are listed in an object, with a "reference name" as the key and the repository definition as the value.

Although PHP implements "associative arrays" in a way that preserves key order, other software that handles a `composer.json` may not.

While not recommended, because no ordering guarantees can be made (see note at the end of https://getcomposer.org/doc/04-schema.md#repositories), the composer CLI generates this notation when using `composer config repo` for $reasons (see https://github.com/composer/composer/issues/9918).

We have to support both notations, otherwise a user composer.json with this notation will not parse. ~~Internally, we only ever use the regular array form (e.g. for our "platform.json"), and user `composer.json` repositories are not processed, so the `Iterator` impl for `ComposerRepositoriesIter` delegating `next()` to `HashMap::values().nth()` is fine (it just has to work, not be efficient) and saves us unnecessary re-implementation.~~

GUS-W-18767798