### PR TITLE
Proof of concept: usage/help screen as the default process type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,6 +1299,7 @@ dependencies = [
  "shell-words",
  "tar",
  "tempfile",
+ "text-to-ascii-art",
  "ureq",
  "url",
  "warned",
@@ -1883,6 +1884,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "text-to-ascii-art"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0c8033260679bf366827afb9e13c308599a4b89aaabc7c6924495f88a248d3"
 
 [[package]]
 name = "thiserror"

--- a/buildpacks/php/Cargo.toml
+++ b/buildpacks/php/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 shell-words = "1"
 tar = { version = "0.4", default-features = false }
+text-to-ascii-art = "0.1"
 ureq = { version = "2", default-features = false, features = ["tls"] }
 url = { version = "2", features = ["serde"] }
 warned = "0.1"

--- a/buildpacks/php/bin/usage_program.sh
+++ b/buildpacks/php/bin/usage_program.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -eu
+set -o pipefail
+
+our_name=$(basename "$0")
+
+show_welcome=
+show_usage=
+process_type=
+if (( $# == 0 )); then
+	# no args at all, main usage screen
+	show_usage=1
+	show_welcome=1
+elif [[ "$1" == "help" ]] || [[ "$1" == "--help" ]]; then
+	# main usage screen unless more args come later
+	show_usage=1
+	shift # drop arg
+fi
+if [[ -n "$show_usage" ]] && (( $# > 0 )); then
+	# show specific process type help instead of main usage screen
+	show_usage=
+	process_type=$1
+	shift # drop arg
+fi
+
+# readarray -d '' uses zero-bytes as the delimiter
+# find all executable files (regular or link) in /cnb/process/ (except ourselves)
+readarray -d '' process_types < <(find /cnb/process/* -maxdepth 0 -executable -type f,l -not -name "$our_name" -printf '%f\0')
+
+if [[ -n "$show_usage" ]]; then
+	if [[ -n "$show_welcome" ]]; then
+		cat >&2 <<-'EOF'
+			
+			██╗    ██╗███████╗██╗      ██████╗ ██████╗ ██╗   ██╗███████╗
+			██║    ██║██╔════╝██║     ██╔════╝██╔═══██╗███╗ ███║██╔════╝
+			██║ █╗ ██║█████╗  ██║     ██║     ██║   ██║█╔████╔█║█████╗  
+			██║███╗██║██╔══╝  ██║     ██║     ██║   ██║█║╚██╔╝█║██╔══╝  
+			╚███╔███╔╝███████╗███████╗╚██████╗╚██████╔╝█║ ╚═╝ █║███████╗
+			 ╚══╝╚══╝ ╚══════╝╚══════╝ ╚═════╝ ╚═════╝ ═╝     ╚╝╚══════╝
+			
+			This help screen is the default process type for your CNB app image.
+			
+			It can provide general instructions, list available process types, show help
+			for specific process types, and execute arbitrary commands.
+			
+			Invoking this Usage Help
+			========================
+			
+			Running your image without any arguments, or with `help' or `--help',
+			will display this screen:
+			
+			    $ docker run --rm <this-image>
+			    $ docker run --rm <this-image> help
+			    $ docker run --rm <this-image> --help
+		EOF
+	else
+		cat >&2 <<-'EOF'
+			
+			██╗   ██╗ ███████╗ █████╗   █████╗ ███████╗
+			██║   ██║ ██╔════╝██╔══██╗ ██╔═══╝ ██╔════╝
+			██║   ██║ ███████╗███████║ ██║ ███╗█████╗  
+			██║   ██║ ╚════██║██╔══██║ ██║  ██║██╔══╝  
+			╚██████╔╝ ███████║██║  ██║ ╚█████╔╝███████╗
+			 ╚═════╝  ╚══════╝╚═╝  ╚═╝  ╚════╝ ╚══════╝
+		EOF
+	fi
+	
+	cat >&2 <<-'EOF'
+		
+		Basic Usage Summary
+		===================
+		
+		    $ docker run --rm <image-name> (help | --help) [process-type]
+		    $ docker run --rm --entrypoint <process-type> <this-image> [<argument>...]
+		    $ docker run --rm [-it] <this-image> [--] <command> [<argument>...]
+		
+		Available Process Types
+		=======================
+		
+		The following process types are available in this image:
+		
+	EOF
+	printf '  - %s\n' "${process_types[@]}" >&2
+	cat >&2 <<-'EOF'
+		
+		Getting Help for a Process Type
+		===============================
+		
+		To show help for a process type, pass its name after `help', like so:
+		
+		    $ docker run --rm <this-image> help <process-type>
+		
+		Launching a Process Type
+		========================
+		
+		To launch a specific process type, specify it as the `--entrypoint', e.g.:
+		
+		    $ docker run --rm --entrypoint <process-type> <this-image>
+		
+		Some process types may require certain environment variables to be set, or
+		ports to be forwarded from the container, in order to be usable. Refer to
+		the help output for the respective process type for further information.
+		
+		For example, a `web' process type typically requires a forwarded port, and
+		the environment variable `$PORT' specifying the in-container port number:
+		
+		    $ docker run --rm --entrypoint web -p 8080:8080 -e PORT=8080 <this-image>
+		
+		Executing commands
+		==================
+		
+		When no entrypoint is specified (or with `--entrypoint usage'), and when
+		not providing `help' or `--help' as the first argument after the image name,
+		the given arguments will be executed as regular commands.
+		
+		To launch an interactive shell, use the `-it' option, and specify `bash' as
+		the command:
+		
+		    $ docker run --rm -it <this-image> bash
+		
+		You may pass arbitrary additional arguments to commands, for example:
+		
+		    $ docker run --rm -it <this-image> bash --login
+		
+		To completely bypass this help tool, specify `--entrypoint launcher', e.g.:
+		
+		    $ docker run --rm -it --entrypoint launcher <this-image> uname -a
+		
+		Further reading
+		===============
+		
+		For additional documentation on how to run buildpacks-built images, refer to
+		the documentation at Buildpacks.io:
+		  https://buildpacks.io/docs/for-app-developers/how-to/build-outputs/specify-launch-process/
+		
+	EOF
+	exit 2
+fi
+
+if [[ -n "$process_type" ]]; then
+	if ! printf '%s\0' "${process_types[@]}" | grep -Fqxz -- "$process_type"; then
+		echo "Unknown process type: $process_type" >&2
+		exit 1
+	fi
+	
+	cat >&2 <<-EOF
+		
+		! /// Usage for entrypoint: \`${process_type}' ///
+		!
+		! === Launching this process type ===
+		!
+		! To launch this process type, specify it as the \`--entrypoint':
+		!   $ docker run --rm --entrypoint ${process_type} <this-image>
+		
+	EOF
+	
+	exit 0
+fi
+
+if [[ "$1" == "--" ]]; then
+	shift
+fi
+
+exec "$@"

--- a/buildpacks/php/src/errors.rs
+++ b/buildpacks/php/src/errors.rs
@@ -3,6 +3,7 @@ pub(crate) mod notices;
 use crate::layers::bootstrap::BootstrapLayerError;
 use crate::layers::composer_env::ComposerEnvLayerError;
 use crate::layers::platform::PlatformLayerError;
+use crate::layers::usage_help::UsageHelpLayerError;
 use crate::layers::usage_program::UsageProgramLayerError;
 use crate::package_manager::composer::{
     ComposerLockVersionError, DependencyInstallationError, PlatformExtractorError,
@@ -101,6 +102,16 @@ impl PhpBuildpackError {
             PhpBuildpackError::PlatformLayer(e) => on_platform_layer_error(e),
             PhpBuildpackError::DependencyInstallation(e) => on_dependency_installation_error(e),
             PhpBuildpackError::ComposerEnvLayer(e) => on_composer_env_layer_error(e),
+            PhpBuildpackError::UsageHelpLayer(e) => match e {
+                UsageHelpLayerError::AsciiHeader(e) => (
+                    "Internal error while generating Usage Help text".to_string(),
+                    e.to_string(),
+                ),
+                UsageHelpLayerError::FileWrite(e) => (
+                    "Internal error while writing Usage Help text".to_string(),
+                    e.to_string(),
+                ),
+            },
             PhpBuildpackError::UsageProgramLayer(e) => match e {
                 UsageProgramLayerError::FileWrite(e) => (
                     "Internal error while writing Usage Help program".to_string(),

--- a/buildpacks/php/src/errors.rs
+++ b/buildpacks/php/src/errors.rs
@@ -3,6 +3,7 @@ pub(crate) mod notices;
 use crate::layers::bootstrap::BootstrapLayerError;
 use crate::layers::composer_env::ComposerEnvLayerError;
 use crate::layers::platform::PlatformLayerError;
+use crate::layers::usage_program::UsageProgramLayerError;
 use crate::package_manager::composer::{
     ComposerLockVersionError, DependencyInstallationError, PlatformExtractorError,
     PlatformFinalizerError,
@@ -100,6 +101,12 @@ impl PhpBuildpackError {
             PhpBuildpackError::PlatformLayer(e) => on_platform_layer_error(e),
             PhpBuildpackError::DependencyInstallation(e) => on_dependency_installation_error(e),
             PhpBuildpackError::ComposerEnvLayer(e) => on_composer_env_layer_error(e),
+            PhpBuildpackError::UsageProgramLayer(e) => match e {
+                UsageProgramLayerError::FileWrite(e) => (
+                    "Internal error while writing Usage Help program".to_string(),
+                    e.to_string(),
+                ),
+            },
         };
         print::error(formatdoc! {"
             {heading}

--- a/buildpacks/php/src/layers.rs
+++ b/buildpacks/php/src/layers.rs
@@ -2,4 +2,5 @@ pub(crate) mod bootstrap;
 pub(crate) mod composer_cache;
 pub(crate) mod composer_env;
 pub(crate) mod platform;
+pub(crate) mod usage_help;
 pub(crate) mod usage_program;

--- a/buildpacks/php/src/layers.rs
+++ b/buildpacks/php/src/layers.rs
@@ -2,3 +2,4 @@ pub(crate) mod bootstrap;
 pub(crate) mod composer_cache;
 pub(crate) mod composer_env;
 pub(crate) mod platform;
+pub(crate) mod usage_program;

--- a/buildpacks/php/src/layers/usage_help.rs
+++ b/buildpacks/php/src/layers/usage_help.rs
@@ -1,0 +1,72 @@
+// TODO: Switch to libcnb's struct layer API.
+#![allow(deprecated)]
+
+use crate::{PhpBuildpack, PhpBuildpackError};
+use libcnb::build::BuildContext;
+use libcnb::data::layer_content_metadata::LayerTypes;
+use libcnb::generic::GenericMetadata;
+use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
+use libcnb::Buildpack;
+use std::collections::HashMap;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+pub(crate) struct UsageHelpLayer<'a> {
+    pub(crate) help_texts: &'a HashMap<&'a str, &'a str>,
+}
+
+impl Layer for UsageHelpLayer<'_> {
+    type Buildpack = PhpBuildpack;
+    type Metadata = GenericMetadata;
+
+    fn types(&self) -> LayerTypes {
+        LayerTypes {
+            build: false,
+            cache: false,
+            launch: true,
+        }
+    }
+
+    fn create(
+        &mut self,
+        _context: &BuildContext<Self::Buildpack>,
+        layer_path: &Path,
+    ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {
+        for (process_type, help_text) in self.help_texts {
+            let mut file = fs::File::create(layer_path.join(process_type).with_extension("txt"))
+                .map_err(UsageHelpLayerError::FileWrite)?;
+            // we join_art() two headers, because the gap between "Help:" and the process type name is too large otherwise
+            let usage = text_to_ascii_art::to_art("Usage".into(), "default", 0, 0, 0)
+                .map_err(UsageHelpLayerError::AsciiHeader)?;
+            // the colon is also pretty wide, so we trim it to seven characters total, with more space on the right side
+            let colon = text_to_ascii_art::to_art(":".into(), "default", 0, 0, 0)
+                .map_err(UsageHelpLayerError::AsciiHeader)?
+                .lines()
+                .map(|line| format!(" {:6}", line.trim_ascii()))
+                .collect::<Vec<String>>()
+                .join("\n");
+            let header = text_to_ascii_art::join_art(
+                &text_to_ascii_art::join_art(&usage, &colon, 0),
+                &text_to_ascii_art::to_art((*process_type).into(), "default", 0, 0, 0)
+                    .map_err(UsageHelpLayerError::AsciiHeader)?,
+                0,
+            );
+            file.write_fmt(format_args!("{header}\n\n{help_text}\n"))
+                .map_err(UsageHelpLayerError::FileWrite)?;
+        }
+        LayerResultBuilder::new(GenericMetadata::default()).build()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum UsageHelpLayerError {
+    FileWrite(std::io::Error),
+    AsciiHeader(String),
+}
+
+impl From<UsageHelpLayerError> for PhpBuildpackError {
+    fn from(error: UsageHelpLayerError) -> Self {
+        Self::UsageHelpLayer(error)
+    }
+}

--- a/buildpacks/php/src/layers/usage_program.rs
+++ b/buildpacks/php/src/layers/usage_program.rs
@@ -1,0 +1,71 @@
+// TODO: Switch to libcnb's struct layer API.
+#![allow(deprecated)]
+
+use crate::{PhpBuildpack, PhpBuildpackError};
+use libcnb::build::BuildContext;
+use libcnb::data::layer_content_metadata::LayerTypes;
+use libcnb::generic::GenericMetadata;
+use libcnb::layer::{Layer, LayerResult, LayerResultBuilder};
+use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
+use libcnb::Buildpack;
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+pub(crate) struct UsageProgramLayer<'a> {
+    pub(crate) program_name: &'a PathBuf,
+}
+
+impl Layer for UsageProgramLayer<'_> {
+    type Buildpack = PhpBuildpack;
+    type Metadata = GenericMetadata;
+
+    fn types(&self) -> LayerTypes {
+        LayerTypes {
+            build: false,
+            cache: false,
+            launch: true,
+        }
+    }
+
+    fn create(
+        &mut self,
+        _context: &BuildContext<Self::Buildpack>,
+        layer_path: &Path,
+    ) -> Result<LayerResult<Self::Metadata>, <Self::Buildpack as Buildpack>::Error> {
+        let bin_dir = layer_path.join("bin");
+        fs::create_dir(layer_path.join(&bin_dir)).map_err(UsageProgramLayerError::FileWrite)?;
+
+        let mut file = fs::File::create(bin_dir.join(self.program_name))
+            .map_err(UsageProgramLayerError::FileWrite)?;
+        let mut perms = file
+            .metadata()
+            .map_err(UsageProgramLayerError::FileWrite)?
+            .permissions();
+        perms.set_mode(perms.mode() | 0o111); // make executable
+        file.set_permissions(perms)
+            .map_err(UsageProgramLayerError::FileWrite)?;
+        file.write_all(include_bytes!("../../bin/usage_program.sh"))
+            .map_err(UsageProgramLayerError::FileWrite)?;
+
+        LayerResultBuilder::new(GenericMetadata::default())
+            .env(
+                LayerEnv::new()
+                    .chainable_insert(Scope::All, ModificationBehavior::Prepend, "PATH", bin_dir)
+                    .chainable_insert(Scope::All, ModificationBehavior::Delimiter, "PATH", ":"),
+            )
+            .build()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum UsageProgramLayerError {
+    FileWrite(std::io::Error),
+}
+
+impl From<UsageProgramLayerError> for PhpBuildpackError {
+    fn from(error: UsageProgramLayerError) -> Self {
+        Self::UsageProgramLayer(error)
+    }
+}


### PR DESCRIPTION
*([scroll down to comments](#issuecomment-3185447351) to see what the output looks like in practice 🙃)*

## Background

Our buildpacks currently set `web` as the default process type, and the Procfile buildpack sets that as the default, too, if present. The process type's command wrapper (e.g. `/lifecycle/launcher/web`) is set as the `ENTRYPOINT` for the image. This wrapper sets the env vars from all buildpacks and layers, and execs the process type's command. Any arguments provided to docker run after the image name are forwarded to this command as additional arguments.

As a result, one typically cannot `docker run <image-name> bash -c "echo hello world"` without specifying `--entrypoint launcher`.

A workaround employed by some buildpacks is to define the default process type's command as `["bash", "-c"]`, and then make the default argument(s) whatever the actual command is.

However, this does not allow for additional arguments, so the above example doesn't work either (only `docker run <image-name> bash`, without further arguments).

## The issue with `web` as the default

Furthermore, having `web` be the default process type is not actually useful in practice, because a user must pass at least `-e PORT=$PORT` and `-p $LOCALPORT:$PORT` to the `docker run` command for the image to work:

```ShellSession
user@localhost:~$ docker run --rm -e PORT=8080 -p 8080:8080 image-name
```

Just launching the default process using `docker run image-name` may cause a successful startup, including a message of having bound to a port (many servers will default to e.g. `8080` if no `$PORT` is in the env), but it will not be reachable, and without some easy to access documentation, users may not quickly determine what they are doing wrong.

## Solution

This proof of concept disables the default process flag for `web`, and sets a new process type, `usage`, as the default instead. This `usage` program shows a help screen with information on how to invoke the image, a list of process types, and usage information for individual process types.

A simple invocation of the image shows usage details and a list of process types:

```ShellSession
user@localhost:~$ docker run --rm image-name
```

The `help` sub-command gives details on how to use a particular process type:

```ShellSession
user@localhost:~$ docker run --rm image-name help web
```

In addition, unless the first argument is `help` or `--help`, the `usage` program `exec`s all remaining arguments, meaning it's possible to launch arbitrary commands out of the box:

```ShellSession
user@localhost:~$ docker run --rm image-name bash -c "echo 'hello world'"
user@localhost:~$ docker run --rm image-name uname -a
user@localhost:~$ docker run --rm image-name -- help # in case 'help' is a binary on $PATH (the 'bash' help command is just a builtin)
```

## Future

This proof of concept is intended to showcase the soundness of this approach, and allow others to test the usability of the idea. For the final implementation, the following should probably be changed:

- move implementation to its own buildpack
- make that buildpack last in the list for all groups in the heroku builder (so that it overrides default setting of `web` by the Procfile buildpack)
- skip execution when building on Heroku (so that no `usage` process shows up in the `heroku ps` process table)
  - fairly easy via e.g. `$DYNO`
- probably have that buildpack emit some special default notes about `-e` and `-p` for the `web` process case
  - could just be a hard-coded default for `web`
- decide whether or not we want the "per-process-type help file" feature (could easily be added later if we deem relatively generic info on process types enough for now, except maybe the above `-e`/`-p` stuff for `web`)
- possibly convert the "entrypoint" `usage.sh` program from Bash to Rust
  - especially if we want to keep the "per-process-type help file" feature, which right now relies on quick-and-dirty grepping of `/layers/config/metadata.toml`
- maybe allow a process type name as the first argument, as if `ENTRYPOINT` was `launcher`, allowing `docker run --rm image-name web` etc
  - easy to add later, hard to remove once it's in ;)

## Notes

1. this implementation currently only works on projects without a `Procfile` (since the Procfile buildpack runs last and re-sets `web` to be the default)
2. Heroku looks for a `web` process type to boot an app for HTTP traffic, not the default process type, so no impact there 💜
3. Once added to the builder, a dedicated buildpack would immediately provide basic usage info to all existing buildpacks! 🎉

[GUS-W-19330133](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-19330133)