### PR TITLE
Update to git-url-parse 0.6.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,9 +688,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git-url-parse"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f0585897f1759477cb87463e92de981ca429ae4fe3500e35e32349729a25aa"
+checksum = "8df306e4dfc91752e89b74c88ee876c8518890600f82255254828f9192dd003c"
 dependencies = [
  "getset",
  "nom",

--- a/composer/Cargo.toml
+++ b/composer/Cargo.toml
@@ -8,7 +8,7 @@ workspace = true
 
 [dependencies]
 derive_more = { version = "2", features = ["deref", "from"] }
-git-url-parse = "0.5.2"
+git-url-parse = "0.6.0"
 monostate = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
Lifetimes (introduced in 0.5) are gone again, so we can once more represent SCP style URLs correctly.

Also added tests.

GUS-W-19771567