### PR TITLE
Stop setting `reviewers` to a language owner in the GHA release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
     with:
       app_id: ${{ vars.LINGUIST_GH_APP_ID }}
       dry_run: ${{ inputs.dry_run }}
-      reviewers: 'dzuelke'
     secrets:
       app_private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
       cnb_registry_token: ${{ secrets.CNB_REGISTRY_RELEASE_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
So that it defaults to the team alias instead, same as for other jointly owned CNBs, like Go:
https://github.com/heroku/buildpacks-go/blob/main/.github/workflows/release.yml