### PR TITLE
Add support for Ubuntu 26.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        builder: ["builder:24", "builder:22"]
+        builder: ["builder:26", "builder:24", "builder:22"]
         arch: ["amd64", "arm64"]
         exclude:
           - builder: "builder:22"
@@ -87,8 +87,7 @@ jobs:
           )
           docker pull "${RUN_IMAGE}"
       # The integration tests are annotated with the `ignore` attribute, allowing us to run
-      # only those and not the unit tests, via the `--ignored` option. On the latest stack
-      # we run all integration tests, but on older stacks we only run stack-specific tests.
+      # only those and not the unit tests, via the `--ignored` option.
       - name: Run integration tests (all tests)
         run: cargo test --locked -- --ignored --test-threads $(($(nproc)+1))
 
@@ -115,8 +114,8 @@ jobs:
         uses: buildpacks/github-actions/setup-pack@06e250da5bb4ccb9a2103719a21d2a7f2252fe83 # v5.11.0
       - name: Pull builder and run images
         run: |
-          docker pull "heroku/builder:24"
-          docker pull "heroku/heroku:24"
+          docker pull "heroku/builder:26"
+          docker pull "heroku/heroku:26"
       - name: Clone getting started guide
         uses: actions/checkout@v6
         with:
@@ -127,6 +126,6 @@ jobs:
       - name: Compile buildpack
         run: cargo libcnb package --target x86_64-unknown-linux-musl
       - name: "PRINT: Getting started guide output"
-        run: pack build my-image --force-color --builder heroku/builder:24 --trust-extra-buildpacks --buildpack packaged/x86_64-unknown-linux-musl/debug/heroku_php --path tmp/guide --pull-policy never
+        run: pack build my-image --force-color --builder heroku/builder:26 --trust-builder --trust-extra-buildpacks --buildpack packaged/x86_64-unknown-linux-musl/debug/heroku_php --path tmp/guide --pull-policy never
       - name: "PRINT: Cached getting started guide output"
-        run: pack build my-image --force-color --builder heroku/builder:24 --trust-extra-buildpacks --buildpack packaged/x86_64-unknown-linux-musl/debug/heroku_php --path tmp/guide --pull-policy never
+        run: pack build my-image --force-color --builder heroku/builder:26 --trust-builder --trust-extra-buildpacks --buildpack packaged/x86_64-unknown-linux-musl/debug/heroku_php --path tmp/guide --pull-policy never

--- a/buildpacks/php/CHANGELOG.md
+++ b/buildpacks/php/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for Ubuntu 26.04 (and thus Heroku-26 / `heroku/builder:26`). ([#303](https://github.com/heroku/buildpacks-php/pull/303))
+
+### Changed
+
+- Rebuilt Apache 2.4.66 with updated APR (1.6.3 -> 1.7.6) and APR-util (1.6.1 -> 1.6.3). ([#303](https://github.com/heroku/buildpacks-php/pull/303))
+
 ## [1.5.2] - 2026-04-15
 
 ### Added

--- a/buildpacks/php/buildpack.toml
+++ b/buildpacks/php/buildpack.toml
@@ -23,6 +23,10 @@ version = "22.04"
 name = "ubuntu"
 version = "24.04"
 
+[[targets.distros]]
+name = "ubuntu"
+version = "26.04"
+
 [[targets]]
 os = "linux"
 arch = "arm64"
@@ -30,6 +34,10 @@ arch = "arm64"
 [[targets.distros]]
 name = "ubuntu"
 version = "24.04"
+
+[[targets.distros]]
+name = "ubuntu"
+version = "26.04"
 
 [metadata.release]
 image = { repository = "docker.io/heroku/buildpack-php" }

--- a/buildpacks/php/src/bootstrap.rs
+++ b/buildpacks/php/src/bootstrap.rs
@@ -8,7 +8,7 @@ use libcnb::layer_env::Scope;
 use std::path::PathBuf;
 
 #[rustfmt::skip]
-pub(crate) const PLATFORM_REPOSITORY_SNAPSHOT: &str = "b8d43052f365f72af811684a2ec53f7341ee4ed559971ce8e709f57057bf0a20";
+pub(crate) const PLATFORM_REPOSITORY_SNAPSHOT: &str = "befb04469eb11c2f4f26f971551b5f49e2625ffd28389e2264f46a5acf40d678";
 const PHP_VERSION: &str = "8.4.20";
 const COMPOSER_VERSION: &str = "2.9.7";
 

--- a/buildpacks/php/src/platform.rs
+++ b/buildpacks/php/src/platform.rs
@@ -40,7 +40,7 @@ pub(crate) fn heroku_stack_name_for_target(target: &Target) -> Result<String, St
         ..
     } = target;
     match (os.as_str(), distro_name.as_str(), distro_version.as_str()) {
-        ("linux", "ubuntu", v @ ("22.04" | "24.04")) => {
+        ("linux", "ubuntu", v @ ("22.04" | "24.04" | "26.04")) => {
             Ok(format!("heroku-{}", v.strip_suffix(".04").unwrap_or(v)))
         }
         _ => Err(format!("{os}-{distro_name}-{distro_version}")),

--- a/buildpacks/php/tests/integration/platform.rs
+++ b/buildpacks/php/tests/integration/platform.rs
@@ -41,7 +41,7 @@ fn platform_test_polyfills() {
                   - apache {version_triple}
                   - boot-scripts {version_triple}
                 ",
-                version_triple = r"\(\d+\.\d+\.\d+\)",
+                version_triple = r"\(\d+\.\d+\.\d+(\+heroku\d+)?\)",
                 bundled = r"\(bundled with php\)",
                 enabled = r"\(already enabled\)"
             }

--- a/buildpacks/php/tests/integration/utils.rs
+++ b/buildpacks/php/tests/integration/utils.rs
@@ -109,13 +109,15 @@ pub(crate) fn smoke_test<P, B>(
 pub(crate) fn target_triple(builder_name: impl AsRef<str>) -> String {
     let target_triple = match builder_name.as_ref() {
         // Compile the buildpack for ARM64 iff the builder supports multi-arch and the host is ARM64.
-        "heroku/builder:24" if cfg!(target_arch = "aarch64") => "aarch64-unknown-linux-musl",
+        "heroku/builder:24" | "heroku/builder:26" if cfg!(target_arch = "aarch64") => {
+            "aarch64-unknown-linux-musl"
+        }
         _ => "x86_64-unknown-linux-musl",
     };
     target_triple.to_string()
 }
 
-const DEFAULT_INTEGRATION_TEST_BUILDER: &str = "heroku/builder:24";
+const DEFAULT_INTEGRATION_TEST_BUILDER: &str = "heroku/builder:26";
 
 const UREQ_RESPONSE_RESULT_EXPECT_MESSAGE: &str = "http request should be successful";
 


### PR DESCRIPTION
Adds support for Ubuntu 26.04 (and thus Heroku-26 / `heroku/builder:26`).

Note: Ubuntu 26.04 is not yet GA upstream, so we don't yet recommend using it in production. See:
https://documentation.ubuntu.com/release-notes/26.04/schedule/

This is the CNB equivalent of:
https://github.com/heroku/heroku-buildpack-php/pull/930

Since we have to update the PHP repository snapshot hash (value taken from the GHA summary [here](https://github.com/heroku/heroku-buildpack-php/actions/runs/24541973507)), it also pulls in the Apache APR rebuild changes for all stacks, from:
https://github.com/heroku/heroku-buildpack-php/pull/939

GUS-W-20775711.