### PR TITLE
May 2026 PHP Updates

### DIFF
--- a/buildpacks/php/CHANGELOG.md
+++ b/buildpacks/php/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- PHP/8.5.6
+- PHP/8.4.21
+- PHP/8.3.31
+- PHP/8.2.31
+- ext-blackfire/2026.4.1
+- ext-mongodb/2.3.1
+- Apache/2.4.67
+- blackfire/2026.4.2
+- librdkafka/2.14.1
+
 ## [1.6.0] - 2026-04-17
 
 ### Added

--- a/buildpacks/php/src/bootstrap.rs
+++ b/buildpacks/php/src/bootstrap.rs
@@ -8,8 +8,8 @@ use libcnb::layer_env::Scope;
 use std::path::PathBuf;
 
 #[rustfmt::skip]
-pub(crate) const PLATFORM_REPOSITORY_SNAPSHOT: &str = "befb04469eb11c2f4f26f971551b5f49e2625ffd28389e2264f46a5acf40d678";
-const PHP_VERSION: &str = "8.4.20";
+pub(crate) const PLATFORM_REPOSITORY_SNAPSHOT: &str = "215ddaedc0bc92b8e80d83c9ee1afec1b47cb715fa1479a44243e7d47227f84c";
+const PHP_VERSION: &str = "8.4.21";
 const COMPOSER_VERSION: &str = "2.9.7";
 
 // TODO: Switch to libcnb's struct layer API.


### PR DESCRIPTION
The usual version bumps for PHP, extensions, and packages.

GUS-W-20573229.
GUS-W-20573230.
GUS-W-20573231.