### PR TITLE
Bump platform repository snapshot for nginx 1.30.1

### DIFF
--- a/buildpacks/php/CHANGELOG.md
+++ b/buildpacks/php/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- nginx/1.30.1
+
 ## [1.6.1] - 2026-05-12
 
 ### Added

--- a/buildpacks/php/src/bootstrap.rs
+++ b/buildpacks/php/src/bootstrap.rs
@@ -8,7 +8,7 @@ use libcnb::layer_env::Scope;
 use std::path::PathBuf;
 
 #[rustfmt::skip]
-pub(crate) const PLATFORM_REPOSITORY_SNAPSHOT: &str = "215ddaedc0bc92b8e80d83c9ee1afec1b47cb715fa1479a44243e7d47227f84c";
+pub(crate) const PLATFORM_REPOSITORY_SNAPSHOT: &str = "b59be0de5133500598f959c0e1fe98ebbe493cd2af0e3b8f739147c010120f5d";
 const PHP_VERSION: &str = "8.4.21";
 const COMPOSER_VERSION: &str = "2.9.7";
 


### PR DESCRIPTION
## Summary

Updates the platform repository snapshot to match the one synced to `-stable/` alongside the nginx 1.30.1 bump in [heroku-buildpack-php#948](https://github.com/heroku/heroku-buildpack-php/pull/948), so the CNB picks up the new package.

W-22598606