### PR TITLE
Bump platform repository snapshot for nginx 1.30.2

### DIFF
--- a/buildpacks/php/CHANGELOG.md
+++ b/buildpacks/php/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- nginx/1.30.2
+
 ## [1.6.2] - 2026-05-21
 
 ### Added

--- a/buildpacks/php/src/bootstrap.rs
+++ b/buildpacks/php/src/bootstrap.rs
@@ -8,7 +8,7 @@ use libcnb::layer_env::Scope;
 use std::path::PathBuf;
 
 #[rustfmt::skip]
-pub(crate) const PLATFORM_REPOSITORY_SNAPSHOT: &str = "b59be0de5133500598f959c0e1fe98ebbe493cd2af0e3b8f739147c010120f5d";
+pub(crate) const PLATFORM_REPOSITORY_SNAPSHOT: &str = "2c9cf744e8286c9975da39ab941ed83fbc630a7eda37d558575df70b79918986";
 const PHP_VERSION: &str = "8.4.21";
 const COMPOSER_VERSION: &str = "2.9.7";
 


### PR DESCRIPTION
## Summary

Updates the platform repository snapshot to match the one synced to `-stable/` alongside the nginx 1.30.2 bump in [heroku-buildpack-php#952](https://github.com/heroku/heroku-buildpack-php/pull/952), so the CNB picks up the new package.

W-22673236