### PR TITLE
Update platform repository snapshot for June 2026

### DIFF
--- a/buildpacks/php/CHANGELOG.md
+++ b/buildpacks/php/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- PHP/8.5.7
+- PHP/8.4.22
+- ext-blackfire/2026.5.0
+- ext-mongodb/2.3.3
+- ext-newrelic/12.7.0.36
+- ext-grpc/1.81.0
+- ext-phalcon/5.13.0
+- Composer/2.10.1
+- Apache/2.4.68
+- Composer/2.2.28
+- Composer/2.9.8
+- blackfire/2026.6.0
+- librdkafka/2.14.2
+
 ## [1.6.3] - 2026-05-26
 
 ### Added

--- a/buildpacks/php/src/bootstrap.rs
+++ b/buildpacks/php/src/bootstrap.rs
@@ -8,9 +8,9 @@ use libcnb::layer_env::Scope;
 use std::path::PathBuf;
 
 #[rustfmt::skip]
-pub(crate) const PLATFORM_REPOSITORY_SNAPSHOT: &str = "2c9cf744e8286c9975da39ab941ed83fbc630a7eda37d558575df70b79918986";
-const PHP_VERSION: &str = "8.4.21";
-const COMPOSER_VERSION: &str = "2.9.7";
+pub(crate) const PLATFORM_REPOSITORY_SNAPSHOT: &str = "4d5be69956447b79233fffac05e2a82178125a1261a49ce1af33e845c2a6c8e0";
+const PHP_VERSION: &str = "8.4.22";
+const COMPOSER_VERSION: &str = "2.9.8";
 
 // TODO: Switch to libcnb's struct layer API.
 #[allow(deprecated)]


### PR DESCRIPTION
Bumps `PLATFORM_REPOSITORY_SNAPSHOT`, `PHP_VERSION` (`php-min`) and `COMPOSER_VERSION` to match the June 2026 platform sync.

GUS-W-20573232.
GUS-W-20573233.
GUS-W-20573234.