### PR TITLE
Enable libcnb Dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,20 @@ updates:
       - "rust"
       - "skip changelog"
     groups:
+      libcnb:
+        patterns:
+          - "libcnb"
+          - "libcnb-*"
+          - "libherokubuildpack"
       rust-dependencies:
         update-types:
           - "minor"
           - "patch"
+        # Work around: https://github.com/dependabot/dependabot-core/issues/11093
+        exclude-patterns:
+          - "libcnb"
+          - "libcnb-*"
+          - "libherokubuildpack"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/buildpacks/php/Cargo.toml
+++ b/buildpacks/php/Cargo.toml
@@ -18,8 +18,8 @@ flate2 = { version = "1", default-features = false, features = ["zlib"] }
 fs-err = "3"
 indexmap = { version = "2", features = ["serde"] }
 indoc = "2"
-libcnb = { version = "0.30", features = ["trace"] }
-libherokubuildpack = "0.30"
+libcnb = { version = "=0.30.4", features = ["trace"] }
+libherokubuildpack = "=0.30.4"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -32,6 +32,6 @@ warned = "0.1"
 [dev-dependencies]
 assert-json-diff = "2"
 figment = { version = "0.10", features = ["toml"] }
-libcnb-test = "0.30"
+libcnb-test = "=0.30.4"
 rstest = "0.26"
 tempfile = "3"


### PR DESCRIPTION
Add a `libcnb` Dependabot group so the libcnb-family crates (`libcnb`, `libcnb-*` and `libherokubuildpack`) are updated together in a single PR, rather than split across the general `rust-dependencies` group.

Dependabot's grouping docs state that when multiple groups are specified, the first group defined wins:
https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--

In practice this is broken: PRs are compared against all groups and can end up in a later group whose settings then prevent the PR being opened - so major libcnb updates were misrouted to `rust-dependencies` and filtered out by its `update-types: ["minor", "patch"]` rule, meaning no PR was opened at all. To work around this, the groups are made non-overlapping by adding a matching `exclude-patterns` to `rust-dependencies`.

See:
https://github.com/dependabot/dependabot-core/issues/11093

See also: https://github.com/heroku/buildpacks-nodejs/pull/1408

The libcnb-family crate versions have also been pinned to exact versions using the `=` syntax, since these crates have a large impact on the behaviour of the buildpack, so we want to control their version more carefully. (We used to pin to an exact version in many CNBs in the past, but removed the pin as part of trying to work out why Dependabot wasn't updating.)

GUS-W-23329202.
