### PR TITLE
Correct the v1.6.5 release date to 2026-07-08

### DIFF
--- a/buildpacks/php/CHANGELOG.md
+++ b/buildpacks/php/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.6.5] - 2026-07-07
+## [1.6.5] - 2026-07-08
 
 ### Changed
 


### PR DESCRIPTION
The release was published on 2026-07-08, not 2026-07-07 — it was delayed by the release-automation issue (heroku/languages-github-actions#383). Correct the CHANGELOG entry date to match.