### PR TITLE
Update platform repository snapshot for July 2026

### DIFF
--- a/buildpacks/php/CHANGELOG.md
+++ b/buildpacks/php/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- PHP/8.2.32
+- PHP/8.3.32
+- PHP/8.4.23
+- PHP/8.5.8
+- ext-grpc/1.82.0
+- ext-newrelic/12.8.0.37
+- ext-blackfire/2026.7.0
+- ext-phalcon/5.16.0
+- blackfire/2026.6.1
+- nginx/1.30.3
+- Composer/2.10.2
+- librdkafka/2.15.0
+
 ## [1.6.5] - 2026-07-08
 
 ### Changed

--- a/buildpacks/php/src/bootstrap.rs
+++ b/buildpacks/php/src/bootstrap.rs
@@ -8,8 +8,8 @@ use libcnb::layer_env::Scope;
 use std::path::PathBuf;
 
 #[rustfmt::skip]
-pub(crate) const PLATFORM_REPOSITORY_SNAPSHOT: &str = "4d5be69956447b79233fffac05e2a82178125a1261a49ce1af33e845c2a6c8e0";
-const PHP_VERSION: &str = "8.4.22";
+pub(crate) const PLATFORM_REPOSITORY_SNAPSHOT: &str = "0dd5d1870a4500e630ccf692ab33549c482447b64c22c83a1ef97da1aaf43788";
+const PHP_VERSION: &str = "8.4.23";
 const COMPOSER_VERSION: &str = "2.9.8";
 
 // TODO: Switch to libcnb's struct layer API.


### PR DESCRIPTION
Bumps `PLATFORM_REPOSITORY_SNAPSHOT` and `PHP_VERSION` (`php-min`) to match the July 2026 platform sync.

GUS-W-20573235.
GUS-W-20573236.
GUS-W-20573237.