### PR TITLE
Update platform repository snapshot for late July 2026

### DIFF
--- a/buildpacks/php/CHANGELOG.md
+++ b/buildpacks/php/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- PHP/8.2.33
+- PHP/8.3.33
+- PHP/8.4.24
+- PHP/8.5.9
+- ext-event/3.1.6
+- ext-grpc/1.83.0
+- ext-newrelic/12.9.0.38
+- ext-phalcon/5.17.0
+- ext-blackfire/2026.7.1
+- blackfire/2026.7.0
+- nginx/1.30.4
+- `ext-phalcon` is now available on Heroku-26 (PHP 8.4 and 8.5).
+
 ## [1.6.6] - 2026-07-08
 
 ### Added

--- a/buildpacks/php/src/bootstrap.rs
+++ b/buildpacks/php/src/bootstrap.rs
@@ -8,8 +8,8 @@ use libcnb::layer_env::Scope;
 use std::path::PathBuf;
 
 #[rustfmt::skip]
-pub(crate) const PLATFORM_REPOSITORY_SNAPSHOT: &str = "0dd5d1870a4500e630ccf692ab33549c482447b64c22c83a1ef97da1aaf43788";
-const PHP_VERSION: &str = "8.4.23";
+pub(crate) const PLATFORM_REPOSITORY_SNAPSHOT: &str = "9eb1c1ecdc9d110dc2fd1eb5269c457d2f6291c8e646e185ba6a8e77082bfa1d";
+const PHP_VERSION: &str = "8.4.24";
 const COMPOSER_VERSION: &str = "2.9.8";
 
 // TODO: Switch to libcnb's struct layer API.


### PR DESCRIPTION
Point the CNB at the late-July platform packages snapshot: the PHP 8.2.33/8.3.33/8.4.24/8.5.9 runtimes, extension and package updates, and ext-phalcon now being available on Heroku-26. Bump the bootstrap php-min to 8.4.24 to match; Composer stays on 2.9.8.

GUS-W-20573238.
GUS-W-20573239.
GUS-W-20573240.
GUS-W-23660944.